### PR TITLE
Add custom error component for client and server

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ThemeProvider, withStyles } from '@material-ui/styles';
+import { Container } from 'next/app';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import PropTypes from 'prop-types';
+import Head from 'next/head';
+
+import AppBar from '@material-ui/core/AppBar';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import Link from '@material-ui/core/Link';
+import theme from '../src/theme';
+
+const logoRatio = 834 / 784;
+const styles = {
+  logo: {
+    position: 'relative',
+    top: '4px',
+    margin: '.8em .8em .8em 1.8em',
+    width: 60,
+    height: 60 * logoRatio,
+  },
+  title: {
+    fontSize: '1.5em',
+    fontWeight: 300,
+    cursor: 'pointer',
+  },
+  error: {
+    margin: '1.8em',
+  },
+};
+
+class Error extends React.Component {
+  static getInitialProps({ res, err }) {
+    let statusCode;
+    if (res) {
+      ({ statusCode } = res);
+    } else {
+      ({ statusCode } = err || null);
+    }
+
+    return { statusCode };
+  }
+
+  render() {
+    const { classes, showHeader, statusCode } = this.props;
+
+    return (
+      <Container>
+        <Head>
+          <title>Unexpected Error - Career Network</title>
+        </Head>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {showHeader && (
+            <header>
+              <AppBar position="static" color="default">
+                <Grid item>
+                  <Grid container alignItems="center">
+                    <Grid item>
+                      <img
+                        src="/static/img/nj.png"
+                        alt="New Jersey Logo"
+                        className={classes.logo}
+                      />
+                    </Grid>
+                    <Grid item>
+                      <Typography variant="h1" color="primary" className={classes.title}>
+                        Career
+                        <br />
+                        Network
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </AppBar>
+            </header>
+          )}
+          <main className={classes.error}>
+            <Typography variant="h4">Unexpected Error</Typography>
+            <Typography variant="subtitle1">
+              The current action could not be performed successfully.
+            </Typography>
+            <Typography variant="body1">
+              Our team has already been notified and will try to fix this issue as soon as possible.
+              If the problem persists, please
+              {' '}
+              <Link href="mailto:careers@gardenstate.tech?subject=Website Feedback">
+                contact us
+              </Link>
+              .
+            </Typography>
+            <br />
+            {statusCode && (
+              <Typography variant="body2">
+                Status Code:
+                {' '}
+                {statusCode}
+              </Typography>
+            )}
+          </main>
+        </ThemeProvider>
+      </Container>
+    );
+  }
+}
+
+Error.propTypes = {
+  showHeader: PropTypes.bool,
+  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  statusCode: PropTypes.number.isRequired,
+};
+
+Error.defaultProps = {
+  showHeader: false,
+};
+
+export default withStyles(styles)(Error);


### PR DESCRIPTION
Following discussions in #19, I've been trying to implement a global error boundary for the application. 

I couldn't make it work by following the regular [React docs](https://reactjs.org/docs/error-boundaries.html) and using a regular error boundary component. Instead I had to tweak the `MyApp` component and capture the errors there.

This PR introduces the following changes:
- Adds a custom error in `pages/_error.js` that will be used by default instead of the one provided by Next.js. It will be automatically rendered when an error happens in the server.
- Tweaks the `MyApp` component to enable error boundaries that are effective client-side. It uses the `Error` component previously defined.
- In theory, since they use the same `Error` component, both server and client errors should look the same. However that does not seem to all be the case because, sometimes, if the error comes from one of the intermediate components and is rendered in the server, some parts of the layout are kept, whereas the error boundaries coming from React (client-side) seem to unmount all components and render only the error.
- Adds `TODOs` in places where we could integrate the error reporting service, once we decide to use one.

Below you can see the differences. They're pretty similar but one of them reuses parts of the existing layout. 
![error-embedded](https://user-images.githubusercontent.com/1306310/60596934-45a5b680-9daa-11e9-89ef-be2b7d576328.png)
![error-with-custom-header](https://user-images.githubusercontent.com/1306310/60596943-48a0a700-9daa-11e9-80c8-411cb328ce4b.png)

Overall, I found a bit difficult to tell apart the client vs server error handling behaviour in Next.js, and could not achieve total parity in both environments. But I guess this is also due to my inexperience with the framework, and we'll be able to refine it over time. If you have any ideas or know how to improve something, please let me know.