### PR TITLE
Update Firestore rules to match the managed ones

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,31 @@
+rules_version = '2';
+
+// General rules:
+//  - least possible privilege
+//  - disallow deletion
+//  - updating seems OK (immutable seems less valuable in a declarative world)
+//     - except for event sources
+
+// Futire:
+//  - impersonation feature?
+//  - dev environments? (ensure don't clobber prod accidentally?)
+
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if false;
+    match /users/{uid} {
+
+	  // any user can read, create, and update anything directly on their user document
+	  allow read, create, update: if request.auth.uid == uid;
+
+      // any user can read, create, and update their own question responses
+	  match /questionResponses/{document} {
+      	allow read, create, update: if request.auth.uid == uid;
+      }
+
+      // action disposition events are immutable: no updating allowed
+      match /actionDispositionEvents/{document} {
+      	allow read, create: if request.auth.uid == uid;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR simply synchronizes the Firestore rules from the code with the ones that were managed by the Firebase console. 

According to the documentation, the rules from `firestore.rules` always have preference over the ones defined in the Firebase console so, from now on, ideally we should only define the rules using this file.

To deploy the rules, you need to execute `firebase deploy --only firestore:rules`.

 

