### PR TITLE
Implement assessment validation

### DIFF
--- a/components/assessment/Question/OptionQuestion.js
+++ b/components/assessment/Question/OptionQuestion.js
@@ -21,10 +21,7 @@ const useStyles = makeStyles(theme => ({
 export default function OptionQuestion(props) {
   const classes = useStyles();
   const {
-    onChange,
-    question,
-    responseOptions,
-    value,
+    onChange, question, responseOptions, value, errors,
   } = props;
 
   const helperText = question.fields['Helper Text'];
@@ -38,6 +35,7 @@ export default function OptionQuestion(props) {
           name: question.id,
           id: question.id,
         }}
+        error={errors[question.id]}
         onChange={e => onChange(e.target.value)}
         value={value}
       >
@@ -47,9 +45,7 @@ export default function OptionQuestion(props) {
           </MenuItem>
         ))}
       </Select>
-      {helperText && (
-        <FormHelperText>{helperText}</FormHelperText>
-      )}
+      {helperText && <FormHelperText>{helperText}</FormHelperText>}
     </FormControl>
   );
 }
@@ -59,6 +55,7 @@ OptionQuestion.propTypes = {
   question: AirtablePropTypes.question.isRequired,
   responseOptions: AirtablePropTypes.questionResponseOptions.isRequired,
   value: PropTypes.string,
+  errors: PropTypes.objectOf(PropTypes.bool).isRequired,
 };
 
 OptionQuestion.defaultProps = {

--- a/components/assessment/Question/TextQuestion.js
+++ b/components/assessment/Question/TextQuestion.js
@@ -16,8 +16,10 @@ export default function TextQuestion(props) {
   const classes = useStyles();
   const {
     onBlur,
-    onChange,
     question,
+    handleChange,
+    values,
+    errors,
     ...restProps
   } = props;
 
@@ -25,11 +27,12 @@ export default function TextQuestion(props) {
     <TextField
       id={question.id}
       disabled={question.fields.Disabled}
-      required
+      error={errors[question.id]}
       label={question.fields.Label}
       className={classes.textField}
       onBlur={e => onBlur(e.target.value)}
-      onChange={e => onChange(e.target.value)}
+      onChange={handleChange}
+      value={values[question.id] || ''}
       margin="normal"
       helperText={question.fields['Helper Text']}
       fullWidth
@@ -41,10 +44,11 @@ export default function TextQuestion(props) {
 TextQuestion.propTypes = {
   autoComplete: PropTypes.string,
   onBlur: PropTypes.func.isRequired,
-  onChange: PropTypes.func.isRequired,
+  handleChange: PropTypes.func.isRequired,
   question: AirtablePropTypes.question.isRequired,
   type: PropTypes.string,
-  value: PropTypes.string.isRequired,
+  values: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])).isRequired,
+  errors: PropTypes.objectOf(PropTypes.bool).isRequired,
 };
 
 TextQuestion.defaultProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,6 +3041,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
+      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
+      }
+    },
     "cross-env": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
@@ -4864,6 +4873,29 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formik": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-1.5.7.tgz",
+      "integrity": "sha512-kZo8lS4WzfC2uivnSkE9DOuX9x+jVjCtIZOlb1A4lHGeURyuLt6eDfwGJzNlcP0lXIwmpANKzegiB8j60B54TA==",
+      "requires": {
+        "create-react-context": "^0.2.2",
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.11",
+        "lodash-es": "^4.17.11",
+        "prop-types": "^15.6.1",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        }
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -6068,6 +6100,11 @@
         "request": "^2.72.0"
       }
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -7170,6 +7207,11 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
     "lodash._isnative": {
       "version": "2.4.1",
@@ -8747,6 +8789,11 @@
         "prop-types": "^15.6.0",
         "warning": "^4.0.1"
       }
+    },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
     "react-firebaseui": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@material-ui/styles": "^4.0.0",
     "clsx": "^1.0.4",
     "firebase": "^6.2.2",
+    "formik": "^1.5.7",
     "jss": "^9.8.7",
     "next": "^8.1.0",
     "nprogress": "^0.2.0",

--- a/src/assessment-helper.js
+++ b/src/assessment-helper.js
@@ -1,0 +1,49 @@
+export function getActiveQuestions(sections, questions) {
+  if (!sections) {
+    return [];
+  }
+
+  return questions.filter((question) => {
+    const entry = question.fields['Question Assessment Entry'] || question.fields['Group Assessment Entry'];
+    const isActive = sections.fields['Assessment Entries'].includes(entry[0]);
+    const isNotBinary = question.fields['Response Type'] !== 'Binary';
+
+    return entry && isActive && isNotBinary;
+  });
+}
+
+export function getDefaultValue(question, user) {
+  // special cases
+  switch (question.fields.Slug) {
+    case 'email':
+      return user.email;
+    case 'preferredFirstName':
+      return user.firstName;
+    default:
+  }
+
+  switch (question.fields['Response Type']) {
+    case 'Text':
+    case 'Number':
+    case 'Email':
+    case 'Phone':
+    case 'Date':
+    case 'Option':
+      return '';
+    case 'Binary':
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+export function retrieveActiveResponses(sections, questions, responses, user) {
+  return getActiveQuestions(sections, questions).reduce((activeResponses, question) => {
+    const activeResponse = responses.find(response => response.data().question.id === question.id);
+    const defaultValue = getDefaultValue(question, user);
+    // eslint-disable-next-line no-param-reassign
+    activeResponses[question.id] = activeResponse ? activeResponse.data().value : defaultValue;
+
+    return activeResponses;
+  }, {});
+}


### PR DESCRIPTION
This PR makes the following changes:

- Enables form input control with the [Formik](https://jaredpalmer.com/formik/) library.
- Validates text and select inputs using the styles provided by Material UI via the `error` attribute. Using the native `required` attribute from HTML 5 is only applicable to text inputs, as it [requires native selects](https://github.com/mui-org/material-ui/issues/11836#issuecomment-405831045) in order to validate them.
- Extracts some shared code and related functions into an external helper (`src/assessment-helper.js`).
