### PR TITLE
Feature: Add Another Activity

### DIFF
--- a/components/dashboard/ActivityInputDialog.js
+++ b/components/dashboard/ActivityInputDialog.js
@@ -348,6 +348,11 @@ function ActivityInputDialog({ show, onClose }) {
             Submit
           </Button>
         )}
+        {success && (
+          <Button autoFocus onClick={resetComponent} color="primary">
+            Add Another Activity
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
*Demo:*
![add another](https://user-images.githubusercontent.com/3971338/70187088-68225f80-16bb-11ea-9cab-6f556166b585.gif)
**
@rossdakin I branched this off of `feature/capture_activity_inputs`. 

Add another activity without closing the modal. 

Trello: https://trello.com/c/DBFwn065/8-2-job-seeker-saves-and-adds-another-activity-without-closing-the-modal-duplicate