### PR TITLE
Bugfix for Activity Type select menu

### DIFF
--- a/components/dashboard/ActivityInputDialog.js
+++ b/components/dashboard/ActivityInputDialog.js
@@ -67,6 +67,9 @@ const useActivityDialogStyles = makeStyles(theme => ({
   toggleButton: {
     marginTop: theme.spacing(2),
   },
+  menuItem: {
+    whiteSpace: 'normal',
+  },
 }));
 
 const ACTIVITY_TYPES = [
@@ -278,7 +281,11 @@ function ActivityInputDialog({ fullScreen, show, onClose }) {
                 }
               >
                 {ACTIVITY_TYPES.map(activity => (
-                  <MenuItem key={activity.value} value={activity.value}>
+                  <MenuItem
+                    key={activity.value}
+                    value={activity.value}
+                    className={classes.menuItem}
+                  >
                     {activity.label}
                   </MenuItem>
                 ))}


### PR DESCRIPTION
<img width="550" alt="Screen Shot 2019-12-17 at 10 29 33 AM" src="https://user-images.githubusercontent.com/42354755/71009400-24b2f280-20b8-11ea-81b1-c075abb11a78.png">

[Trello Card](https://trello.com/c/D132fMn7/63-activity-drop-down-on-mobile-text-runs-off-the-screen-in-the-drop-down-menu)

Fix for the menu options not wrapping (thus being cutoff when on mobile)