### PR TITLE
Make submit button fullWidth in ActivityInputDialog

### DIFF
--- a/components/dashboard/ActivityInputDialog.js
+++ b/components/dashboard/ActivityInputDialog.js
@@ -425,12 +425,12 @@ function ActivityInputDialog({ fullScreen, show, onClose }) {
       </DialogContent>
       <DialogActions>
         {!success && (
-          <Button autoFocus onClick={handleSave} color="primary">
+          <Button autoFocus onClick={handleSave} fullWidth color="primary">
             Submit
           </Button>
         )}
         {success && (
-          <Button autoFocus onClick={resetComponent} color="primary">
+          <Button autoFocus onClick={resetComponent} fullWidth color="primary">
             Add Another Activity
           </Button>
         )}


### PR DESCRIPTION
Dialog Actions (buttons) were being hidden by the Intercom chat button on mobile. To make button clickable, they are now full width. (NOTE: This fix has not been extended to any other dialog)

[Trello Card](https://trello.com/c/14ydFbue/62-add-activity-submit-button-blocked-by-chat-button-on-mobile)