### PR TITLE
Bugfix for emojis overlapping 

### DIFF
--- a/components/dashboard/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles(theme => ({
   buttons: {
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(2),
+    maxWidth: '75%',
   },
   emoji: {
     fontSize: theme.spacing(10),
@@ -37,7 +38,7 @@ const EmojiButton = ({ emoji, label, onClick }) => {
   };
 
   return (
-    <Grid item xs={6} sm={2} style={{ textAlign: 'center' }}>
+    <Grid item style={{ textAlign: 'center' }}>
       <Button onClick={handleClick} data-intercom={`sentiment-${label.toLowerCase()}`}>
         <Typography align="center">
           <span className={classes.emoji} role="img" aria-label={label}>
@@ -98,10 +99,18 @@ const SentimentTracker = () => {
       <Typography component="h4" variant="h4" align="center">
         How are you feeling today?
       </Typography>
-      <Grid container className={classes.buttons} justify="center" alignItems="center">
-        {sentiments.map(sentiment => (
-          <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
-        ))}
+      <Grid container justify="center">
+        <Grid
+          container
+          item
+          className={classes.buttons}
+          justify="space-between"
+          alignItems="center"
+        >
+          {sentiments.map(sentiment => (
+            <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
+          ))}
+        </Grid>
       </Grid>
     </Paper>
   );


### PR DESCRIPTION
Fix text/emojis overlap when the window is shrunk

[Trello Card](https://trello.com/c/uiEiN206/80-bug-on-emojis-overlapping-emojis)
[Live Env](https://nj-career-network-dev4.firebaseapp.com/dashboard/)

<img width="632" alt="Screen Shot 2020-01-02 at 3 25 17 PM" src="https://user-images.githubusercontent.com/40243087/71690962-26490f80-2d74-11ea-8dde-e9f55266246a.png">

Issue 
![image (2)](https://user-images.githubusercontent.com/40243087/71690995-3a8d0c80-2d74-11ea-96ba-e88f256b1228.png)
