### PR TITLE
Disable redirect to dashboard from Privacy/Terms/About page

### DIFF
--- a/components/AppManager.js
+++ b/components/AppManager.js
@@ -52,7 +52,11 @@ export default function AppManager(props) {
       if (userIsCoach) {
         url = '/coaching';
       } else if (userIsAssessmentComplete) {
-        url = Router.router && Router.route === '/progress' ? '/progress' : '/dashboard';
+        url =
+          Router.router &&
+          ['/progress', '/about', '/privacy-policy', '/terms-of-service'].includes(Router.route)
+            ? Router.route
+            : '/dashboard';
       }
 
       (async () => {


### PR DESCRIPTION
Fix for redirect to dashboard from Privacy/Terms/About page when user login

[Trello card](https://trello.com/c/lF8z1d91/83-navigating-directly-to-privacy-terms-about-pages-with-an-account-re-directs-you-off-that-page-and-auto-logs-you-in-to-dashboard)

[Live Env](https://nj-career-network-dev4.firebaseapp.com/)