### PR TITLE
Show empty state for confidence meter when no self-reported activities entered

### DIFF
--- a/components/Gauge.js
+++ b/components/Gauge.js
@@ -4,18 +4,23 @@ import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 
 function Gauge(props) {
-  const { diameter, stroke, strokeWidth, percentage, label } = props;
+  const { diameter, stroke, strokeWidth, percentage, label, disabled } = props;
   const calculatedPercent = Math.trunc(percentage * 100);
   const coordinateForCircle = diameter / 2;
   const radius = (diameter - 2 * strokeWidth) / 2;
   const circumference = Math.PI * radius;
-  const semiCirclePercentage = (calculatedPercent / 100) * circumference;
+  const semiCirclePercentage = disabled ? circumference : (calculatedPercent / 100) * circumference;
+
   return (
     <Box display="flex" justifyContent="center" alignItems="flex-end" position="relative">
       <svg width={diameter} height={diameter / 2} style={{ transform: 'rotateY(180deg)' }}>
         <defs>
           <linearGradient id="percentGradient" x1="0" y1="0" x2="1" y2="1">
             <stop offset="0%" stopColor={stroke} />
+            <stop offset="100%" stopColor="#ffffff" />
+          </linearGradient>
+          <linearGradient id="greyGradient" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="#979797" />
             <stop offset="100%" stopColor="#ffffff" />
           </linearGradient>
         </defs>
@@ -38,7 +43,7 @@ function Gauge(props) {
           cy={coordinateForCircle}
           r={radius}
           fill="none"
-          stroke="url(#percentGradient)"
+          stroke={disabled ? 'url(#greyGradient)' : 'url(#percentGradient)'}
           strokeWidth={strokeWidth}
           strokeDasharray={circumference}
           style={{
@@ -49,14 +54,16 @@ function Gauge(props) {
           strokeLinecap="round"
         />
       </svg>
-      <Box position="absolute" width={1}>
-        <Typography variant="h5" align="center" style={{ fontWeight: 'bold' }}>
-          {calculatedPercent}%
-        </Typography>
-        <Typography variant="body2" align="center" color="textSecondary">
-          {label}
-        </Typography>
-      </Box>
+      {!disabled && (
+        <Box position="absolute" width={1}>
+          <Typography variant="h5" align="center" style={{ fontWeight: 'bold' }}>
+            {calculatedPercent}%
+          </Typography>
+          <Typography variant="body2" align="center" color="textSecondary">
+            {label}
+          </Typography>
+        </Box>
+      )}
     </Box>
   );
 }
@@ -67,12 +74,14 @@ Gauge.propTypes = {
   diameter: PropTypes.number,
   percentage: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
 };
 
 Gauge.defaultProps = {
   stroke: '#1881c5',
   strokeWidth: 10,
   diameter: 218,
+  disabled: false,
 };
 
 export default Gauge;

--- a/components/dashboard/ActivityCategoryTable.js
+++ b/components/dashboard/ActivityCategoryTable.js
@@ -45,14 +45,27 @@ export default function ActivityCategoryTable(props) {
   const subsetByCategories = Object.keys(totalCounts).map(key => {
     return { category: key, subset: subsetCounts[key] || 0, total: totalCounts[key] };
   });
+  const isEmpty = totalActivitiesCount === 0;
 
   return (
     <>
       <Box mb={4} mx={4}>
         <Gauge
           label={label}
-          percentage={totalActivitiesCount === 0 ? 0 : subsetActivitiesCount / totalActivitiesCount}
+          percentage={isEmpty ? 0 : subsetActivitiesCount / totalActivitiesCount}
+          disabled={isEmpty}
         />
+        {isEmpty && (
+          <Box mt={1}>
+            <Typography variant="h6" align="center" style={{ fontSize: '1.5em' }} gutterBottom>
+              No Activities Logged
+            </Typography>
+            <Typography variant="body2" align="center">
+              You have not logged any activities yet. Start logging your activities and we’ll help
+              you track your confidence level over time.
+            </Typography>
+          </Box>
+        )}
       </Box>
       <Divider />
       <Table>


### PR DESCRIPTION
Display a grey speedometer with text when no self-reported activities entered

<img width="413" alt="confidence" src="https://user-images.githubusercontent.com/40243087/72547037-d67d4480-3859-11ea-8e6b-ce9f59bed9d6.png">

[Trello card](https://trello.com/c/6P7zhxqh/59-display-an-empty-state-for-confidence-level-feelings-speedometer-if-a-jobseeker-has-not-yet-entered-any-self-reported-activities)
[Live env](https://nj-career-network-dev5.firebaseapp.com/dashboard/)