### PR TITLE
Fix task card text overlappping in small screen

### DIFF
--- a/components/dashboard/Task.js
+++ b/components/dashboard/Task.js
@@ -53,9 +53,12 @@ const useStyles = makeStyles(theme => ({
     marginBottom: theme.spacing(3),
   },
   type: {
-    position: 'relative',
-    top: -theme.spacing(2.5),
     marginBottom: theme.spacing(3.5),
+    [theme.breakpoints.up('sm')]: {
+      position: 'relative',
+      top: -theme.spacing(2.5),
+      marginBottom: theme.spacing(3.5),
+    },
   },
   summaryType: {
     position: 'absolute',


### PR DESCRIPTION
<img width="577" alt="Screen Shot 2020-01-21 at 3 12 31 PM" src="https://user-images.githubusercontent.com/40243087/72840167-a7a00d80-3c61-11ea-8c1d-d82ca0ca8110.png">

[Trello card](https://trello.com/c/iknrdEXa/124-bug-card-ux-on-small-screens)

[Live env](https://nj-career-network-dev5.firebaseapp.com/dashboard/)
