### PR TITLE
Bugfix: Emoji and circle positioning  windows 10

### DIFF
--- a/components/dashboard/EmojiCircle.js
+++ b/components/dashboard/EmojiCircle.js
@@ -5,26 +5,23 @@ function EmojiCircle(props) {
   const { emoji, diameter, fillColor, stroke, strokeWidth } = props;
   const coordinateForCircle = diameter / 2;
   const radius = (diameter - 2 * strokeWidth) / 2;
-  const emojiSize = diameter * 0.6;
-  const coordinateXForEmoji = coordinateForCircle - emojiSize / 2;
-  const coordinateYForEmoji = coordinateForCircle + emojiSize / 2 - strokeWidth * 4;
 
   return (
-    <svg height={diameter} width={diameter}>
-      <g>
-        <circle
-          cx={coordinateForCircle}
-          cy={coordinateForCircle}
-          r={radius}
-          stroke={stroke}
-          strokeWidth={strokeWidth}
-          fill={fillColor}
-        />
-        <text x={coordinateXForEmoji} y={coordinateYForEmoji} fontSize={emojiSize}>
-          {emoji}
-        </text>
-      </g>
-    </svg>
+    <>
+      <svg height={diameter} width={diameter}>
+        <g>
+          <circle
+            cx={coordinateForCircle}
+            cy={coordinateForCircle}
+            r={radius}
+            stroke={stroke}
+            strokeWidth={strokeWidth}
+            fill={fillColor}
+          />
+        </g>
+      </svg>
+      <div style={{ marginTop: '-63.5px', fontSize: '33px' }}>{emoji}</div>
+    </>
   );
 }
 

--- a/components/dashboard/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker.js
@@ -35,11 +35,10 @@ const EmojiButton = ({ emoji, label, onClick }) => {
     <Grid item style={{ textAlign: 'center' }}>
       <Button onClick={handleClick} data-intercom={`sentiment-${label.toLowerCase()}`}>
         <Box m={1} align="center">
-          <span aria-label={label}>
+          <span aria-label={label} role="img">
             <EmojiCircle emoji={emoji} />
           </span>
-          <br />
-          {label}
+          <div style={{ marginTop: '0.5rem' }}>{label}</div>
         </Box>
       </Button>
     </Grid>


### PR DESCRIPTION
Emoji display is not centered. Seen on Firefox and Chrome w/ PC.

[Trello card](https://trello.com/c/blEttB2L/133-bug-fix-emoji-and-circle-display-in-the-mood-tracker)
[Live env](https://nj-career-network-dev2.firebaseapp.com/)

<img width="1268" alt="Screen Shot 2020-01-29 at 1 33 31 PM" src="https://user-images.githubusercontent.com/40243087/73385914-fc640980-429b-11ea-9a3c-6ebeb1fb717b.png">

