### PR TITLE
#138 display count for search results 

### DIFF
--- a/components/employmentOutlook/AutocompleteDropdown.js
+++ b/components/employmentOutlook/AutocompleteDropdown.js
@@ -2,15 +2,23 @@ import { InstantSearch, Configure, connectAutoComplete } from 'react-instantsear
 import { makeStyles } from '@material-ui/styles';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import isEmpty from 'lodash/isEmpty';
+import ListSubheader from '@material-ui/core/ListSubheader';
 import PropTypes from 'prop-types';
 import React from 'react';
 import SearchIcon from '@material-ui/icons/Search';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   wrapIcon: {
     display: 'inline-flex',
+  },
+  listbox: {
+    paddingTop: 0,
+  },
+  listheader: {
+    backgroundColor: 'white',
+    color: theme.palette.text.light,
   },
 }));
 
@@ -19,9 +27,19 @@ function AutocompleteSearch(props) {
   const classes = useStyles();
   const options = hits.map(option => option.Occupation);
 
+  const renderGroup = params => [
+    <ListSubheader key={params.key} className={classes.listheader}>
+      {params.key} ({params.children.length} Results)
+    </ListSubheader>,
+    params.children,
+  ];
+
   return (
     <Autocomplete
       id="occupation-autocomplete-select"
+      classes={{
+        listbox: classes.listbox,
+      }}
       options={options}
       noOptionsText={
         <>
@@ -37,6 +55,8 @@ function AutocompleteSearch(props) {
       onChange={(event, val) =>
         isEmpty(val) ? onDropdownValueChange('') : onDropdownValueChange(val)
       }
+      groupBy={() => 'Occupations'}
+      renderGroup={renderGroup}
       renderInput={params => (
         <TextField
           variant="outlined"

--- a/components/employmentOutlook/AutocompleteDropdown.js
+++ b/components/employmentOutlook/AutocompleteDropdown.js
@@ -32,6 +32,7 @@ function AutocompleteSearch(props) {
         </>
       }
       value={value}
+      filterOptions={occupations => occupations}
       onInputChange={(event, val) => refine(val)}
       onChange={(event, val) =>
         isEmpty(val) ? onDropdownValueChange('') : onDropdownValueChange(val)

--- a/src/theme.js
+++ b/src/theme.js
@@ -18,6 +18,7 @@ const theme = createMuiTheme({
     },
     text: {
       secondary: '#44444f',
+      light: '#696974',
     },
     background: {
       default: '#ffffff',


### PR DESCRIPTION
[Trello card](https://trello.com/c/x2lOUy6V/138-the-number-of-searched-results-should-be-displayed-when-jobseeker-search-through-and-select-occupation)

[Live env](https://nj-career-network-dev4.firebaseapp.com/employment-outlook/)

- Removed the unwanted matching/filtering (from the Autocomplete widget) applied to the results.
- Total number of search results is showed in the dropdown.

<img width="739" alt="Screen Shot 2020-02-13 at 1 56 04 PM" src="https://user-images.githubusercontent.com/40243087/74468323-a761ef00-4e68-11ea-913b-4bd1ef4853dc.png">

