### PR TITLE
#149 Persistent feeling bar with Success Feedback

### DIFF
--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -312,17 +312,36 @@ export default function Dashboard(props) {
           </Typography>
         </ScaffoldContainer>
       </BackgroundHeader>
-
-      {showSentiment && (
-        <ScaffoldContainer className={classes.container}>
-          <SentimentTracker
-            onRecord={onRecordSentiment}
-            onClose={onSentimentClose}
-            user={user.firstName}
-            isComplete={isSentimentLoggedToday}
-          />
-        </ScaffoldContainer>
-      )}
+      <Flags
+        authorizedFlags={['completeSentiment']}
+        renderOn={() => (
+          <>
+            {showSentiment && (
+              <ScaffoldContainer className={classes.container}>
+                <SentimentTracker
+                  onRecord={onRecordSentiment}
+                  onClose={onSentimentClose}
+                  user={user.firstName}
+                  isComplete={isSentimentLoggedToday}
+                />
+              </ScaffoldContainer>
+            )}
+          </>
+        )}
+        renderOff={() => (
+          <>
+            {!isSentimentLoggedToday && (
+              <ScaffoldContainer className={classes.container}>
+                <SentimentTracker
+                  onRecord={onRecordSentiment}
+                  onClose={onSentimentClose}
+                  user={user.firstName}
+                />
+              </ScaffoldContainer>
+            )}
+          </>
+        )}
+      />
 
       <ScaffoldContainer>
         <Box className={classes.grid}>

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -272,14 +272,20 @@ export default function Dashboard(props) {
   const tasks = getTasks(props, TASK_COUNT_LIMIT);
   const doneTaskCount = allTaskDispositionEvents.length;
   const [activeDialog, setActiveDialog] = useState();
-  const [sentimentClose, setSentimentClose] = useState(false);
   const isSentimentLoggedToday =
     user.lastSentimentTimestamp && isToday(user.lastSentimentTimestamp.toDate());
+  const isSentimentClosedToday =
+    user.lastSentimentCloseTimestamp && isToday(user.lastSentimentCloseTimestamp.toDate());
 
-  const showSentiment = !isSentimentLoggedToday || (isSentimentLoggedToday && !sentimentClose);
+  const showSentiment =
+    !isSentimentLoggedToday || (isSentimentLoggedToday && !isSentimentClosedToday);
 
   const onRecordSentiment = () => {
     userDocRef.set({ lastSentimentTimestamp: new Date() }, { merge: true });
+  };
+
+  const onSentimentClose = () => {
+    userDocRef.set({ lastSentimentCloseTimestamp: new Date() }, { merge: true });
   };
 
   useEffect(() => {
@@ -311,8 +317,9 @@ export default function Dashboard(props) {
         <ScaffoldContainer className={classes.container}>
           <SentimentTracker
             onRecord={onRecordSentiment}
-            onClose={() => setSentimentClose(true)}
+            onClose={onSentimentClose}
             user={user.firstName}
+            isComplete={isSentimentLoggedToday}
           />
         </ScaffoldContainer>
       )}

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -277,8 +277,7 @@ export default function Dashboard(props) {
   const isSentimentClosedToday =
     user.lastSentimentCloseTimestamp && isToday(user.lastSentimentCloseTimestamp.toDate());
 
-  const showSentiment =
-    !isSentimentLoggedToday || (isSentimentLoggedToday && !isSentimentClosedToday);
+  const showSentiment = !isSentimentLoggedToday || !isSentimentClosedToday;
 
   const onRecordSentiment = () => {
     userDocRef.set({ lastSentimentTimestamp: new Date() }, { merge: true });

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -13,7 +13,6 @@ import Typography from '@material-ui/core/Typography';
 
 import { isDone, mostRecent } from '../../src/app-helper';
 import { useAuth } from '../Auth';
-import { useSnackbar } from '../Snackbar';
 import ActivityCategoryTable from '../history/ActivityCategoryTable';
 import ActivityInputDialog from '../activityInput/ActivityInputDialog';
 import AirtablePropTypes from '../Airtable/PropTypes';
@@ -22,7 +21,7 @@ import EmploymentOutlookLauchpad from './EmploymentOutlookLauchpad';
 import FirebasePropTypes from '../Firebase/PropTypes';
 import ProgressFeed from './ProgressFeed';
 import ScaffoldContainer from '../ScaffoldContainer';
-import SentimentTracker from './SentimentTracker';
+import SentimentTracker from './SentimentTracker/SentimentTracker';
 import TaskList from './TaskList';
 import TimeDistanceParser from '../../src/time-distance-parser';
 import UpcomingInterviewDialog from './UpcomingInterviewDialog/UpcomingInterviewDialog';
@@ -254,7 +253,6 @@ const DIALOGS = {
 // eslint-disable-next-line sonarjs/cognitive-complexity
 export default function Dashboard(props) {
   const classes = useStyles();
-  const showMessage = useSnackbar();
   const { user, userDocRef } = useAuth();
   const {
     allConditions,
@@ -274,11 +272,14 @@ export default function Dashboard(props) {
   const tasks = getTasks(props, TASK_COUNT_LIMIT);
   const doneTaskCount = allTaskDispositionEvents.length;
   const [activeDialog, setActiveDialog] = useState();
-  const showSentiment =
-    !user.lastSentimentTimestamp || !isToday(user.lastSentimentTimestamp.toDate());
+  const [sentimentClose, setSentimentClose] = useState(false);
+  const isSentimentLoggedToday =
+    user.lastSentimentTimestamp && isToday(user.lastSentimentTimestamp.toDate());
+
+  const showSentiment = !isSentimentLoggedToday || (isSentimentLoggedToday && !sentimentClose);
+
   const onRecordSentiment = () => {
     userDocRef.set({ lastSentimentTimestamp: new Date() }, { merge: true });
-    showMessage(`Thank you for sharing, ${user.firstName}`);
   };
 
   useEffect(() => {
@@ -308,7 +309,11 @@ export default function Dashboard(props) {
 
       {showSentiment && (
         <ScaffoldContainer className={classes.container}>
-          <SentimentTracker onRecord={onRecordSentiment} />
+          <SentimentTracker
+            onRecord={onRecordSentiment}
+            onClose={() => setSentimentClose(true)}
+            user={user.firstName}
+          />
         </ScaffoldContainer>
       )}
 

--- a/components/dashboard/SentimentTracker/SentimentComplete.js
+++ b/components/dashboard/SentimentTracker/SentimentComplete.js
@@ -12,8 +12,8 @@ const useStyles = makeStyles(theme => ({
   },
   closeButton: {
     position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
+    right: 0,
+    top: theme.spacing(-8),
     color: theme.palette.grey[500],
   },
 }));
@@ -24,7 +24,7 @@ export default function SentimentComplete(props) {
 
   return (
     <Box position="relative">
-      <Typography className={classes.title} component="h4" variant="h6">
+      <Typography className={classes.title} variant="h6">
         Thank you for sharing, {user}
       </Typography>
       <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>

--- a/components/dashboard/SentimentTracker/SentimentComplete.js
+++ b/components/dashboard/SentimentTracker/SentimentComplete.js
@@ -7,6 +7,9 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(theme => ({
+  title: {
+    margin: theme.spacing(8, 0, 8, 4),
+  },
   closeButton: {
     position: 'absolute',
     right: theme.spacing(1),
@@ -21,7 +24,7 @@ export default function SentimentComplete(props) {
 
   return (
     <Box position="relative">
-      <Typography component="h4" variant="h6" align="center">
+      <Typography className={classes.title} component="h4" variant="h6">
         Thank you for sharing, {user}
       </Typography>
       <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>

--- a/components/dashboard/SentimentTracker/SentimentComplete.js
+++ b/components/dashboard/SentimentTracker/SentimentComplete.js
@@ -2,6 +2,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
@@ -13,8 +14,16 @@ const useStyles = makeStyles(theme => ({
   closeButton: {
     position: 'absolute',
     right: 0,
-    top: theme.spacing(-8),
+    top: theme.spacing(-9),
     color: theme.palette.grey[500],
+  },
+  paper: {
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(5, 4, 3),
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(2, 2, 2),
+    },
+    marginBottom: theme.spacing(8),
   },
 }));
 
@@ -23,14 +32,16 @@ export default function SentimentComplete(props) {
   const { onClose, user } = props;
 
   return (
-    <Box position="relative">
-      <Typography className={classes.title} variant="h6">
-        Thank you for sharing, {user}
-      </Typography>
-      <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
-        <CloseIcon />
-      </IconButton>
-    </Box>
+    <Paper className={classes.paper} elevation={3}>
+      <Box position="relative">
+        <Typography className={classes.title} variant="h6">
+          Thank you for sharing, {user}
+        </Typography>
+        <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+    </Paper>
   );
 }
 

--- a/components/dashboard/SentimentTracker/SentimentComplete.js
+++ b/components/dashboard/SentimentTracker/SentimentComplete.js
@@ -1,0 +1,37 @@
+import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles(theme => ({
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+}));
+
+export default function SentimentComplete(props) {
+  const classes = useStyles();
+  const { onClose, user } = props;
+
+  return (
+    <Box position="relative">
+      <Typography component="h4" variant="h6" align="center">
+        Thank you for sharing, {user}
+      </Typography>
+      <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
+        <CloseIcon />
+      </IconButton>
+    </Box>
+  );
+}
+
+SentimentComplete.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  user: PropTypes.string.isRequired,
+};

--- a/components/dashboard/SentimentTracker/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker/SentimentTracker.js
@@ -14,9 +14,9 @@ import SentimentComplete from './SentimentComplete';
 const useStyles = makeStyles(theme => ({
   paper: {
     marginTop: theme.spacing(2),
-    padding: theme.spacing(5, 4, 3),
+    padding: theme.spacing(2, 2, 2),
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(2, 2, 2),
+      padding: theme.spacing(0.5, 2, 0.8),
     },
     marginBottom: theme.spacing(8),
   },
@@ -96,8 +96,39 @@ const SentimentTracker = props => {
   ];
 
   return (
-    <>
-      {!complete && (
+    <Flags
+      authorizedFlags={['completeSentiment']}
+      renderOn={() => (
+        <>
+          {!complete && (
+            <Paper className={classes.paper} elevation={3} data-intercom="sentiment-container">
+              <Grid container direction="row" justify="space-evenly" alignItems="center">
+                <Grid item xs={12} sm={3} md={3}>
+                  <Typography component="h4" variant="h6" align="center">
+                    How are you feeling today?
+                  </Typography>
+                </Grid>
+                <Grid
+                  xs={12}
+                  sm={7}
+                  md={7}
+                  container
+                  item
+                  className={classes.buttons}
+                  justify="space-between"
+                  alignItems="center"
+                >
+                  {sentiments.map(sentiment => (
+                    <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
+                  ))}
+                </Grid>
+              </Grid>
+            </Paper>
+          )}
+          {complete && <SentimentComplete onClose={onClose} user={user} />}
+        </>
+      )}
+      renderOff={() => (
         <Paper className={classes.paper} elevation={3} data-intercom="sentiment-container">
           <Grid container direction="row" justify="space-evenly" alignItems="center">
             <Grid item xs={12} sm={3} md={3}>
@@ -122,13 +153,7 @@ const SentimentTracker = props => {
           </Grid>
         </Paper>
       )}
-      {complete && (
-        <Flags
-          authorizedFlags={['completeSentiment']}
-          renderOn={() => <SentimentComplete onClose={onClose} user={user} />}
-        />
-      )}
-    </>
+    />
   );
 };
 

--- a/components/dashboard/SentimentTracker/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker/SentimentTracker.js
@@ -60,14 +60,15 @@ EmojiButton.propTypes = {
 };
 
 const SentimentTracker = props => {
-  const { onRecord, onClose, user } = props;
+  const { onRecord, onClose, user, isComplete } = props;
   const { userDocRef } = useAuth();
-  const [complete, setComplete] = useState(false);
+  const [complete, setComplete] = useState(isComplete);
 
   const classes = useStyles();
 
   const submitSentiment = sentiment => {
     setComplete(true);
+
     const data = {
       timestamp: new Date(),
       ...sentiment,
@@ -127,10 +128,12 @@ SentimentTracker.propTypes = {
   onRecord: PropTypes.func,
   onClose: PropTypes.func.isRequired,
   user: PropTypes.string.isRequired,
+  isComplete: PropTypes.bool,
 };
 
 SentimentTracker.defaultProps = {
   onRecord: null,
+  isComplete: false,
 };
 
 export default SentimentTracker;

--- a/components/dashboard/SentimentTracker/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker/SentimentTracker.js
@@ -1,3 +1,4 @@
+import { Flags } from 'react-feature-flags';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
@@ -95,32 +96,39 @@ const SentimentTracker = props => {
   ];
 
   return (
-    <Paper className={classes.paper} elevation={3} data-intercom="sentiment-container">
+    <>
       {!complete && (
-        <Grid container direction="row" justify="space-evenly" alignItems="center">
-          <Grid item xs={12} sm={3} md={3}>
-            <Typography component="h4" variant="h6" align="center">
-              How are you feeling today?
-            </Typography>
+        <Paper className={classes.paper} elevation={3} data-intercom="sentiment-container">
+          <Grid container direction="row" justify="space-evenly" alignItems="center">
+            <Grid item xs={12} sm={3} md={3}>
+              <Typography component="h4" variant="h6" align="center">
+                How are you feeling today?
+              </Typography>
+            </Grid>
+            <Grid
+              xs={12}
+              sm={7}
+              md={7}
+              container
+              item
+              className={classes.buttons}
+              justify="space-between"
+              alignItems="center"
+            >
+              {sentiments.map(sentiment => (
+                <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
+              ))}
+            </Grid>
           </Grid>
-          <Grid
-            xs={12}
-            sm={7}
-            md={7}
-            container
-            item
-            className={classes.buttons}
-            justify="space-between"
-            alignItems="center"
-          >
-            {sentiments.map(sentiment => (
-              <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
-            ))}
-          </Grid>
-        </Grid>
+        </Paper>
       )}
-      {complete && <SentimentComplete onClose={onClose} user={user} />}
-    </Paper>
+      {complete && (
+        <Flags
+          authorizedFlags={['completeSentiment']}
+          renderOn={() => <SentimentComplete onClose={onClose} user={user} />}
+        />
+      )}
+    </>
   );
 };
 

--- a/components/dashboard/SentimentTracker/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker/SentimentTracker.js
@@ -4,10 +4,11 @@ import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import Typography from '@material-ui/core/Typography';
 
-import { useAuth } from '../Auth';
+import { useAuth } from '../../Auth';
+import SentimentComplete from './SentimentComplete';
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -59,12 +60,14 @@ EmojiButton.propTypes = {
 };
 
 const SentimentTracker = props => {
-  const { onRecord } = props;
+  const { onRecord, onClose, user } = props;
   const { userDocRef } = useAuth();
+  const [complete, setComplete] = useState(false);
 
   const classes = useStyles();
 
   const submitSentiment = sentiment => {
+    setComplete(true);
     const data = {
       timestamp: new Date(),
       ...sentiment,
@@ -92,33 +95,38 @@ const SentimentTracker = props => {
 
   return (
     <Paper className={classes.paper} elevation={3} data-intercom="sentiment-container">
-      <Grid container direction="row" justify="space-evenly" alignItems="center">
-        <Grid item xs={12} sm={3} md={3}>
-          <Typography component="h4" variant="h6" align="center">
-            How are you feeling today?
-          </Typography>
+      {!complete && (
+        <Grid container direction="row" justify="space-evenly" alignItems="center">
+          <Grid item xs={12} sm={3} md={3}>
+            <Typography component="h4" variant="h6" align="center">
+              How are you feeling today?
+            </Typography>
+          </Grid>
+          <Grid
+            xs={12}
+            sm={7}
+            md={7}
+            container
+            item
+            className={classes.buttons}
+            justify="space-between"
+            alignItems="center"
+          >
+            {sentiments.map(sentiment => (
+              <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
+            ))}
+          </Grid>
         </Grid>
-        <Grid
-          xs={12}
-          sm={7}
-          md={7}
-          container
-          item
-          className={classes.buttons}
-          justify="space-between"
-          alignItems="center"
-        >
-          {sentiments.map(sentiment => (
-            <EmojiButton {...sentiment} key={sentiment.label} onClick={submitSentiment} />
-          ))}
-        </Grid>
-      </Grid>
+      )}
+      {complete && <SentimentComplete onClose={onClose} user={user} />}
     </Paper>
   );
 };
 
 SentimentTracker.propTypes = {
   onRecord: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+  user: PropTypes.string.isRequired,
 };
 
 SentimentTracker.defaultProps = {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -30,6 +30,10 @@ const featureFlags = [
     name: 'employmentOutlook',
     isActive: true,
   },
+  {
+    name: 'completeSentiment',
+    isActive: true,
+  },
 ];
 
 Sentry.init({

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -32,7 +32,7 @@ const featureFlags = [
   },
   {
     name: 'completeSentiment',
-    isActive: true,
+    isActive: false,
   },
 ];
 

--- a/src/User.js
+++ b/src/User.js
@@ -96,4 +96,8 @@ export default class User {
   get lastSentimentTimestamp() {
     return this.userData.lastSentimentTimestamp;
   }
+
+  get lastSentimentCloseTimestamp() {
+    return this.userData.lastSentimentCloseTimestamp;
+  }
 }


### PR DESCRIPTION
**Feature Overview**

Show success feedback after user logged a sentiment, the feedback bar will persist for the rest of the day until user hits close button.

[Trello card](https://trello.com/c/n28BQ6Td/149-provide-jobseeker-with-success-feedback-with-the-feeling-container) 
[Live env](https://nj-career-network-dev5.firebaseapp.com/dashboard/)

<img width="1180" alt="Screen Shot 2020-02-14 at 3 41 53 PM" src="https://user-images.githubusercontent.com/40243087/74776034-d6ab9e00-5264-11ea-927f-0291c867ee36.png">

**Notes**
- A timestamp field is added to Firestore to track the last time the user closes the feedback bar, allows the feedback bar to be persistent.
- Add feature flag 'completeSentiment' to turn on/off this feature.

