### PR TITLE
#166 Feature: Close feeling bar after user completed the recommended action

### DIFF
--- a/components/dashboard/Action.js
+++ b/components/dashboard/Action.js
@@ -9,7 +9,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import Linkify from 'linkifyjs/react';
 import PropTypes from 'prop-types';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
 import withMobileDialog from '@material-ui/core/withMobileDialog';
 
@@ -20,8 +20,18 @@ import AirtablePropTypes from '../Airtable/PropTypes';
 // eslint-disable-next-line sonarjs/cognitive-complexity
 function Action(props) {
   const { userDocRef } = useAuth();
-  const [open, setOpen] = React.useState(false);
-  const { action, allQualityChecks, disabled, isDone, onDone, fullScreen } = props;
+  const {
+    action,
+    allQualityChecks,
+    disabled,
+    isDone,
+    onDone,
+    fullScreen,
+    taskTitle,
+    triggered,
+    onActionClose,
+  } = props;
+  const [open, setOpen] = React.useState(triggered || false);
   const qualityChecks = allQualityChecks.filter(
     qc => action.fields['Action ID'] === qc.fields['Action ID'][0]
   );
@@ -54,6 +64,7 @@ function Action(props) {
 
   function handleClose() {
     setOpen(false);
+    onActionClose();
   }
 
   function handleDone() {
@@ -71,6 +82,10 @@ function Action(props) {
     newVerifications[i] = event.target.checked;
     setVerifications(newVerifications);
   }
+
+  useEffect(() => {
+    setOpen(triggered || false);
+  }, [triggered]);
 
   return (
     <>
@@ -128,7 +143,10 @@ function Action(props) {
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
-        <DialogTitle id="alert-dialog-title">{action.fields.Title}</DialogTitle>
+        <DialogTitle id="alert-dialog-title">
+          <Typography variant="body2">{taskTitle}</Typography>
+          {action.fields.Title}
+        </DialogTitle>
         <DialogContent>
           <Typography>
             <Linkify
@@ -207,6 +225,14 @@ Action.propTypes = {
   disabled: PropTypes.bool.isRequired,
   isDone: PropTypes.bool.isRequired,
   onDone: PropTypes.func.isRequired,
+  taskTitle: PropTypes.string.isRequired,
+  triggered: PropTypes.bool,
+  onActionClose: PropTypes.func,
+};
+
+Action.defaultProps = {
+  triggered: false,
+  onActionClose: null,
 };
 
 export default withMobileDialog()(Action);

--- a/components/dashboard/Action.js
+++ b/components/dashboard/Action.js
@@ -30,6 +30,7 @@ function Action(props) {
     taskTitle,
     triggered,
     onActionClose,
+    onActionComplete,
   } = props;
   const [open, setOpen] = React.useState(triggered || false);
   const qualityChecks = allQualityChecks.filter(
@@ -69,6 +70,7 @@ function Action(props) {
 
   function handleDone() {
     handleClose();
+    onActionComplete();
     disposition('done');
     onDone();
   }
@@ -228,11 +230,13 @@ Action.propTypes = {
   taskTitle: PropTypes.string.isRequired,
   triggered: PropTypes.bool,
   onActionClose: PropTypes.func,
+  onActionComplete: PropTypes.func,
 };
 
 Action.defaultProps = {
   triggered: false,
   onActionClose: null,
+  onActionComplete: null,
 };
 
 export default withMobileDialog()(Action);

--- a/components/dashboard/ActionList.js
+++ b/components/dashboard/ActionList.js
@@ -8,7 +8,7 @@ import AirtablePropTypes from '../Airtable/PropTypes';
 import FirebasePropTypes from '../Firebase/PropTypes';
 
 export default function ActionList(props) {
-  const { actions, actionDispositionEvents, onAllDone, ...restProps } = props;
+  const { actions, actionDispositionEvents, onAllDone, actionTriggered, ...restProps } = props;
   const onDone = (action, i) => {
     // last action in the task
     if (i === actions.length - 1) {
@@ -26,6 +26,7 @@ export default function ActionList(props) {
             disabled={i > 0 && !isDone(actions[i - 1], actionDispositionEvents, 'actionId')}
             isDone={isDone(action, actionDispositionEvents, 'actionId')}
             onDone={() => onDone(action, i)}
+            triggered={actionTriggered && action.id === actionTriggered}
             {...restProps}
           />
         ))}
@@ -39,4 +40,12 @@ ActionList.propTypes = {
   actionDispositionEvents: FirebasePropTypes.querySnapshot.isRequired,
   allQualityChecks: AirtablePropTypes.qualityChecks.isRequired,
   onAllDone: PropTypes.func.isRequired,
+  taskTitle: PropTypes.string.isRequired,
+  actionTriggered: PropTypes.string,
+  onActionClose: PropTypes.func,
+};
+
+ActionList.defaultProps = {
+  actionTriggered: null,
+  onActionClose: null,
 };

--- a/components/dashboard/ActionList.js
+++ b/components/dashboard/ActionList.js
@@ -43,9 +43,11 @@ ActionList.propTypes = {
   taskTitle: PropTypes.string.isRequired,
   actionTriggered: PropTypes.string,
   onActionClose: PropTypes.func,
+  onActionComplete: PropTypes.func,
 };
 
 ActionList.defaultProps = {
   actionTriggered: null,
   onActionClose: null,
+  onActionComplete: null,
 };

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -301,6 +301,11 @@ export default function Dashboard(props) {
     setShowNextAction(true);
   };
 
+  const handleActionComplete = () => {
+    setShowNextAction(false);
+    onSentimentClose();
+  };
+
   useEffect(() => {
     window.Intercom('update', { 'tasks-completed': doneTaskCount });
   }, [doneTaskCount]);
@@ -386,6 +391,7 @@ export default function Dashboard(props) {
               allTaskDispositionEvents={allTaskDispositionEvents}
               showNextAction={showNextAction}
               onActionClose={() => setShowNextAction(false)}
+              onActionComplete={handleActionComplete}
               {...restProps}
             />
           </Box>

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -272,19 +272,33 @@ export default function Dashboard(props) {
   const tasks = getTasks(props, TASK_COUNT_LIMIT);
   const doneTaskCount = allTaskDispositionEvents.length;
   const [activeDialog, setActiveDialog] = useState();
+  const [showNextAction, setShowNextAction] = useState(false);
   const isSentimentLoggedToday =
     user.lastSentimentTimestamp && isToday(user.lastSentimentTimestamp.toDate());
   const isSentimentClosedToday =
     user.lastSentimentCloseTimestamp && isToday(user.lastSentimentCloseTimestamp.toDate());
 
-  const showSentiment = !isSentimentLoggedToday || !isSentimentClosedToday;
+  const showSentiment =
+    !isSentimentLoggedToday || (isSentimentLoggedToday && !isSentimentClosedToday);
 
-  const onRecordSentiment = () => {
-    userDocRef.set({ lastSentimentTimestamp: new Date() }, { merge: true });
+  const onRecordSentiment = sentiment => {
+    const lastSentiment = {
+      label: sentiment.label,
+      timestamp: new Date(),
+      closeTimestamp: null,
+    };
+    userDocRef.set({ lastSentiment }, { merge: true });
   };
 
   const onSentimentClose = () => {
-    userDocRef.set({ lastSentimentCloseTimestamp: new Date() }, { merge: true });
+    const lastSentiment = {
+      closeTimestamp: new Date(),
+    };
+    userDocRef.set({ lastSentiment }, { merge: true });
+  };
+
+  const onPromptAction = () => {
+    setShowNextAction(true);
   };
 
   useEffect(() => {
@@ -320,8 +334,9 @@ export default function Dashboard(props) {
                 <SentimentTracker
                   onRecord={onRecordSentiment}
                   onClose={onSentimentClose}
-                  user={user.firstName}
+                  record={user.lastSentimentLabel ? user.lastSentimentLabel : ''}
                   isComplete={isSentimentLoggedToday}
+                  onClick={onPromptAction}
                 />
               </ScaffoldContainer>
             )}
@@ -369,6 +384,8 @@ export default function Dashboard(props) {
               allActions={allActions}
               allActionDispositionEvents={allActionDispositionEvents}
               allTaskDispositionEvents={allTaskDispositionEvents}
+              showNextAction={showNextAction}
+              onActionClose={() => setShowNextAction(false)}
               {...restProps}
             />
           </Box>

--- a/components/dashboard/SentimentTracker/SentimentComplete.js
+++ b/components/dashboard/SentimentTracker/SentimentComplete.js
@@ -1,51 +1,93 @@
 import { makeStyles } from '@material-ui/core/styles';
-import Box from '@material-ui/core/Box';
-import IconButton from '@material-ui/core/IconButton';
+import Button from '@material-ui/core/Button';
 import CloseIcon from '@material-ui/icons/Close';
+import Grid from '@material-ui/core/Grid';
+import IconButton from '@material-ui/core/IconButton';
 import Paper from '@material-ui/core/Paper';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
+const SENTIMENT_TYPES = {
+  Motivated: {
+    message: 'Fantastic! What have you been putting off doing that you could do today?',
+  },
+  Hopeful: {
+    message: 'Great! What’s something new that you could learn today?',
+  },
+  Okay: {
+    message: 'We hear you! Consider what you could do to give your day a boost.',
+  },
+  Discouraged: {
+    message:
+      'It’s normal to feel discouraged during your search. What can you do to lift your mood today? Throughout your day proactively address your mood by doing things, such as changing your scenery, calling a loved one, or going for a walk, in order to bring a new perspective to your day.',
+  },
+  Worried: {
+    message:
+      'Sometimes your worries about the future can sap your motivation. Consider how you can minimize your worries so that you can make strides in your job search today.',
+  },
+};
+
 const useStyles = makeStyles(theme => ({
+  paper: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(8),
+  },
+  container: {
+    position: 'relative',
+    padding: theme.spacing(4),
+    [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing(6, 4, 6, 4),
+    },
+  },
   title: {
-    margin: theme.spacing(8, 0, 8, 4),
+    fontSize: '1.1rem',
   },
   closeButton: {
     position: 'absolute',
     right: 0,
-    top: theme.spacing(-9),
+    top: 0,
     color: theme.palette.grey[500],
-  },
-  paper: {
-    marginTop: theme.spacing(2),
-    padding: theme.spacing(5, 4, 3),
-    [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(2, 2, 2),
-    },
-    marginBottom: theme.spacing(8),
   },
 }));
 
 export default function SentimentComplete(props) {
   const classes = useStyles();
-  const { onClose, user } = props;
+  const { onClose, value, onClick } = props;
 
   return (
     <Paper className={classes.paper} elevation={3}>
-      <Box position="relative">
-        <Typography className={classes.title} variant="h6">
-          Thank you for sharing, {user}
-        </Typography>
+      <Grid
+        container
+        className={classes.container}
+        alignItems="center"
+        direction="row"
+        justify="space-between"
+        spacing={2}
+      >
+        <Grid item sm={12} md>
+          <Typography variant="h6" className={classes.title} gutterBottom>
+            {SENTIMENT_TYPES[value].message}
+          </Typography>
+          <Typography variant="body1">
+            Let’s dive right into getting your first daily goal started.
+          </Typography>
+        </Grid>
         <IconButton aria-label="close" className={classes.closeButton} onClick={onClose}>
           <CloseIcon />
         </IconButton>
-      </Box>
+        <Grid item xs={12} sm={12} md={3} style={{ display: 'flex', justifyContent: 'center' }}>
+          <Button size="large" variant="contained" onClick={onClick} color="primary">
+            Start Goal
+          </Button>
+        </Grid>
+      </Grid>
     </Paper>
   );
 }
 
 SentimentComplete.propTypes = {
   onClose: PropTypes.func.isRequired,
-  user: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };

--- a/components/dashboard/SentimentTracker/SentimentTracker.js
+++ b/components/dashboard/SentimentTracker/SentimentTracker.js
@@ -61,13 +61,15 @@ EmojiButton.propTypes = {
 };
 
 const SentimentTracker = props => {
-  const { onRecord, onClose, user, isComplete } = props;
+  const { onRecord, onClose, record, isComplete, onClick } = props;
   const { userDocRef } = useAuth();
   const [complete, setComplete] = useState(isComplete);
+  const [value, setValue] = useState(record);
 
   const classes = useStyles();
 
   const submitSentiment = sentiment => {
+    setValue(sentiment.label);
     setComplete(true);
 
     const data = {
@@ -125,7 +127,7 @@ const SentimentTracker = props => {
               </Grid>
             </Paper>
           )}
-          {complete && <SentimentComplete onClose={onClose} user={user} />}
+          {complete && <SentimentComplete onClose={onClose} value={value} onClick={onClick} />}
         </>
       )}
       renderOff={() => (
@@ -160,8 +162,9 @@ const SentimentTracker = props => {
 SentimentTracker.propTypes = {
   onRecord: PropTypes.func,
   onClose: PropTypes.func.isRequired,
-  user: PropTypes.string.isRequired,
+  record: PropTypes.string.isRequired,
   isComplete: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
 };
 
 SentimentTracker.defaultProps = {

--- a/components/dashboard/Task.js
+++ b/components/dashboard/Task.js
@@ -178,6 +178,7 @@ export default function Task(props) {
           <ActionList
             actionDispositionEvents={getActionDispositionEvents()}
             onAllDone={onAllActionsDone}
+            taskTitle={task.fields.Title}
             {...restProps}
           />
         </div>
@@ -193,4 +194,11 @@ Task.propTypes = {
   allTaskDispositionEvents: FirebasePropTypes.querySnapshot.isRequired,
   allActionDispositionEvents: FirebasePropTypes.querySnapshot.isRequired,
   allQualityChecks: AirtablePropTypes.qualityChecks.isRequired,
+  actionTriggered: PropTypes.string,
+  onActionClose: PropTypes.func,
+};
+
+Task.defaultProps = {
+  actionTriggered: null,
+  onActionClose: null,
 };

--- a/components/dashboard/Task.js
+++ b/components/dashboard/Task.js
@@ -196,9 +196,11 @@ Task.propTypes = {
   allQualityChecks: AirtablePropTypes.qualityChecks.isRequired,
   actionTriggered: PropTypes.string,
   onActionClose: PropTypes.func,
+  onActionComplete: PropTypes.func,
 };
 
 Task.defaultProps = {
   actionTriggered: null,
   onActionClose: null,
+  onActionComplete: null,
 };

--- a/components/dashboard/TaskList.js
+++ b/components/dashboard/TaskList.js
@@ -88,9 +88,11 @@ TaskList.propTypes = {
   tasks: AirtablePropTypes.tasks.isRequired,
   showNextAction: PropTypes.bool,
   onActionClose: PropTypes.func,
+  onActionComplete: PropTypes.func,
 };
 
 TaskList.defaultProps = {
   showNextAction: false,
   onActionClose: null,
+  onActionComplete: null,
 };

--- a/src/User.js
+++ b/src/User.js
@@ -94,10 +94,14 @@ export default class User {
   }
 
   get lastSentimentTimestamp() {
-    return this.userData.lastSentimentTimestamp;
+    return this.userData.lastSentiment && this.userData.lastSentiment.timestamp;
+  }
+
+  get lastSentimentLabel() {
+    return this.userData.lastSentiment && this.userData.lastSentiment.label;
   }
 
   get lastSentimentCloseTimestamp() {
-    return this.userData.lastSentimentCloseTimestamp;
+    return this.userData.lastSentiment && this.userData.lastSentiment.closeTimestamp;
   }
 }


### PR DESCRIPTION
If a user has entered a goal via the "Start Goal" button on the mood tracker and has completed the next step in the goal, the mood tracker will be closed.

This is a follow-up story for [Card 151](https://trello.com/c/byVYWN8o/151-prompt-jobseeker-to-make-progress-on-their-first-recommended-activity)

[Trello card](https://trello.com/c/Yq1SSumE/166-request-elevate-jobseekers-dashboard-content-after-completing-their-first-task) 