### PR TITLE
Bugfix: Activity dialog fields overlap on IE 11

### DIFF
--- a/components/activityInput/ActivityInputDialog.js
+++ b/components/activityInput/ActivityInputDialog.js
@@ -376,7 +376,6 @@ function ActivityInputDialog({ fullScreen, show, onClose }) {
               </InputLabel>
               <Grid item xs={12} className={classes.toggleButton}>
                 <ToggleButton
-                  className={classes.toggleButton}
                   options={DIFFICULTY_LEVELS}
                   value={String(formValues.difficultyLevel)}
                   handleChange={e => setFormValues({ ...formValues, difficultyLevel: e })}
@@ -389,15 +388,7 @@ function ActivityInputDialog({ fullScreen, show, onClose }) {
 
             <FormControl className={classes.formControl}>
               <InputLabel shrink>This activity made me feel… (select all that apply)</InputLabel>
-              <Grid
-                className={classes.toggleButton}
-                container
-                xs={12}
-                item
-                justify="space-evenly"
-                alignItems="center"
-                direction="row"
-              >
+              <Grid item xs={12} className={classes.toggleButton}>
                 <ToggleButton
                   options={shuffledFeelings}
                   multiSelect

--- a/components/activityInput/ActivityInputDialog.js
+++ b/components/activityInput/ActivityInputDialog.js
@@ -33,10 +33,10 @@ const FORM_ELEMENT_MARGINS = [1, 0];
 const useActivityDialogStyles = makeStyles(theme => ({
   formControl: {
     width: '100%',
-    margin: theme.spacing(...FORM_ELEMENT_MARGINS),
+    margin: theme.spacing(1, 0, 0, 0),
   },
   textField: {
-    margin: theme.spacing(...FORM_ELEMENT_MARGINS),
+    margin: theme.spacing(1, 0, 0, 0),
   },
   toggleButton: {
     marginTop: theme.spacing(2),

--- a/components/activityInput/ActivityInputDialog.js
+++ b/components/activityInput/ActivityInputDialog.js
@@ -28,8 +28,6 @@ import SubmitSuccess from './SubmitSuccess';
 import ToggleButton from '../ToggleButton';
 import validate from './ActivityInputValidationRules';
 
-const FORM_ELEMENT_MARGINS = [1, 0];
-
 const useActivityDialogStyles = makeStyles(theme => ({
   formControl: {
     width: '100%',
@@ -174,10 +172,10 @@ function ActivityInputDialog({ fullScreen, show, onClose }) {
     overrides: {
       MuiFormControl: {
         marginNormal: {
-          marginTop: theme.spacing(FORM_ELEMENT_MARGINS[0]),
-          marginRight: theme.spacing(FORM_ELEMENT_MARGINS[1]),
-          marginBottom: theme.spacing(FORM_ELEMENT_MARGINS[0]),
-          marginLeft: theme.spacing(FORM_ELEMENT_MARGINS[1]),
+          marginTop: theme.spacing(1),
+          marginRight: theme.spacing(0),
+          marginBottom: theme.spacing(1),
+          marginLeft: theme.spacing(0),
         },
       },
     },


### PR DESCRIPTION
[Trello card](https://trello.com/c/HvUVOSl1/125-bug-report-activity-on-ie11)

![Annotation 2020-03-09 173948](https://user-images.githubusercontent.com/40243087/76260129-899c6580-622d-11ea-8673-54eb1c5b121c.png)


Bug:
<img width="400" alt="Screen_Shot_2020-01-21_at_2 31 39_PM" src="https://user-images.githubusercontent.com/40243087/76258922-e9454180-622a-11ea-8d14-1db1407cd88c.png">
