### PR TITLE
#203 Feature: Add access to covid-19 resources on dashboard

### DIFF
--- a/components/dashboard/CovidJobsAccess.js
+++ b/components/dashboard/CovidJobsAccess.js
@@ -34,7 +34,7 @@ const handleClick = () => {
   window.Intercom('trackEvent', 'covid-access-button-clicked');
 };
 
-function CovidResourcesAccess() {
+function CovidJobsAccess() {
   const classes = useStyles();
 
   return (
@@ -45,7 +45,7 @@ function CovidResourcesAccess() {
       <Card className={classes.card} variant="outlined">
         <CardContent className={classes.cardContent}>
           <Typography variant="h6" gutterBottom>
-            COVID-19 Resources
+            COVID-19 Job Portal
           </Typography>
           <Typography variant="body1" gutterBottom>
             Have you lost your job or have your hours reduced as a result of COVID-19? Visit the
@@ -68,4 +68,4 @@ function CovidResourcesAccess() {
   );
 }
 
-export default CovidResourcesAccess;
+export default CovidJobsAccess;

--- a/components/dashboard/CovidResourcesAccess.js
+++ b/components/dashboard/CovidResourcesAccess.js
@@ -3,9 +3,8 @@ import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
-import NextLink from 'next/link';
+import FlagIcon from '@material-ui/icons/Flag';
 import React from 'react';
-import TrackChangesIcon from '@material-ui/icons/TrackChanges';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(theme => ({
@@ -32,36 +31,41 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const handleClick = () => {
-  window.Intercom('trackEvent', 'explore-button-clicked');
+  window.Intercom('trackEvent', 'covid-access-button-clicked');
 };
 
-function EmploymentOutlookLauchpad() {
+function CovidResourcesAccess() {
   const classes = useStyles();
 
   return (
     <>
       <div className={classes.iconContainer}>
-        <TrackChangesIcon fontSize="large" />
+        <FlagIcon fontSize="large" />
       </div>
       <Card className={classes.card} variant="outlined">
         <CardContent className={classes.cardContent}>
           <Typography variant="h6" gutterBottom>
-            Employment Outlook
+            COVID-19 Resources
           </Typography>
           <Typography variant="body1" gutterBottom>
-            Learn about the outlook in your area for the occupation that you want.
+            If you have urgent questions here are some resources that New Jersey has made available
+            for residents.
           </Typography>
         </CardContent>
         <CardActions>
-          <NextLink href="/employment-outlook">
-            <Button className={classes.button} fullWidth onClick={handleClick}>
-              EXPLORE
-            </Button>
-          </NextLink>
+          <Button
+            className={classes.button}
+            href="https://jobs.covid19.nj.gov/"
+            target="_blank"
+            fullWidth
+            onClick={handleClick}
+          >
+            Learn More
+          </Button>
         </CardActions>
       </Card>
     </>
   );
 }
 
-export default EmploymentOutlookLauchpad;
+export default CovidResourcesAccess;

--- a/components/dashboard/CovidResourcesAccess.js
+++ b/components/dashboard/CovidResourcesAccess.js
@@ -48,8 +48,8 @@ function CovidResourcesAccess() {
             COVID-19 Resources
           </Typography>
           <Typography variant="body1" gutterBottom>
-            If you have urgent questions here are some resources that New Jersey has made available
-            for residents.
+            Have you lost your job or have your hours reduced as a result of COVID-19? Visit the
+            COVID-19 Jobs Portal.
           </Typography>
         </CardContent>
         <CardActions>

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -17,6 +17,7 @@ import ActivityInputDialog from '../activityInput/ActivityInputDialog';
 import AirtablePropTypes from '../Airtable/PropTypes';
 import AssessmentCompleteDialog from './AssessmentCompleteDialog';
 import BackgroundHeader from '../BackgroundHeader';
+import CovidResourcesAccess from './CovidResourcesAccess';
 import EmploymentOutlookLauchpad from './EmploymentOutlookLauchpad';
 import FirebasePropTypes from '../Firebase/PropTypes';
 import ProgressFeed from './ProgressFeed';
@@ -408,7 +409,10 @@ export default function Dashboard(props) {
             />
           </Box>
           <Box className={classes.gridL} position="relative">
-            <EmploymentOutlookLauchpad />
+            <CovidResourcesAccess />
+            <Box mt={8} style={{ position: 'relative' }}>
+              <EmploymentOutlookLauchpad />
+            </Box>
           </Box>
           <Box className={classes.gridR}>
             <Card variant="outlined">

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -17,7 +17,7 @@ import ActivityInputDialog from '../activityInput/ActivityInputDialog';
 import AirtablePropTypes from '../Airtable/PropTypes';
 import AssessmentCompleteDialog from './AssessmentCompleteDialog';
 import BackgroundHeader from '../BackgroundHeader';
-import CovidResourcesAccess from './CovidResourcesAccess';
+import CovidJobsAccess from './CovidJobsAccess';
 import EmploymentOutlookLauchpad from './EmploymentOutlookLauchpad';
 import FirebasePropTypes from '../Firebase/PropTypes';
 import ProgressFeed from './ProgressFeed';
@@ -409,7 +409,7 @@ export default function Dashboard(props) {
             />
           </Box>
           <Box className={classes.gridL} position="relative">
-            <CovidResourcesAccess />
+            <CovidJobsAccess />
             <Box mt={8} style={{ position: 'relative' }}>
               <EmploymentOutlookLauchpad />
             </Box>


### PR DESCRIPTION
Provide access to https://jobs.covid19.nj.gov/ by adding a card in the left rail of the dashboard

[Trello card](https://trello.com/c/FMZHnbAt/203-provide-access-to-reliable-resources-and-tools-for-jobseekers-to-connect-to-the-job-portal)

[Live env](https://nj-career-network-dev5.firebaseapp.com/dashboard)

<img width="426" alt="Screen Shot 2020-03-25 at 6 04 58 PM" src="https://user-images.githubusercontent.com/40243087/77590530-4d6f3300-6ec4-11ea-82e9-087d9afd8629.png">
