### PR TITLE
#197 Feature: Allow sign-in with Facebook and Twitter 

### DIFF
--- a/components/Auth/AuthDialog.js
+++ b/components/Auth/AuthDialog.js
@@ -29,8 +29,9 @@ function AuthDialog(props) {
           Before we get started, please sign in using one of your accounts below.
           <br />
           <small>
-            We require the use of a Google or Yahoo account to sign up for a NJCN account to ensure
-            a simple and secure sign in. Your account data is private and secure – we only use this
+            We currently offer the below methods of sign up for a NJCN account to ensure a simple
+            and secure sign in. We will not pull data or have access to any of your other profiles
+            or accounts. With your NJCN account, your data is private and secure -- we only use this
             information to provide and improve our service.
           </small>
         </DialogContentText>

--- a/components/Auth/AuthForm.js
+++ b/components/Auth/AuthForm.js
@@ -42,7 +42,7 @@ export default function AuthForm(props) {
     signInOptions: [
       // Leave the lines as is for the providers you want to offer your users.
       auth.GoogleAuthProvider.PROVIDER_ID,
-      // auth.FacebookAuthProvider.PROVIDER_ID,
+      auth.FacebookAuthProvider.PROVIDER_ID,
       // {
       //   provider: 'microsoft.com',
       //   providerName: 'Microsoft',
@@ -57,7 +57,7 @@ export default function AuthForm(props) {
         scopes: ['sdpp-r'],
       },
       // auth.GithubAuthProvider.PROVIDER_ID,
-      // auth.TwitterAuthProvider.PROVIDER_ID,
+      auth.TwitterAuthProvider.PROVIDER_ID,
       // auth.EmailAuthProvider.PROVIDER_ID,
       // auth.PhoneAuthProvider.PROVIDER_ID,
     ],


### PR DESCRIPTION
[Trello card](https://trello.com/c/sYDW4fkB/197-reduce-the-barrier-to-entry-for-jobseekers-as-they-sign-up-for-njcn)

**Notes for Twitter app configuration:**

[ **Additional permissions**](https://developer.twitter.com/en/docs/basics/apps/guides/app-permissions) is required to obtain user's email address.

<img width="793" alt="Screen Shot 2020-03-30 at 1 29 56 PM" src="https://user-images.githubusercontent.com/40243087/77943201-dacad280-728a-11ea-80ae-f90b425c913f.png">
