### PR TITLE
#202 Feature: COVID-19 information banner

### DIFF
--- a/components/AppManager.js
+++ b/components/AppManager.js
@@ -13,6 +13,7 @@ import Router from 'next/router';
 
 import { useAuth } from './Auth';
 import { useSnackbar } from './Snackbar';
+import Banner from './Banner';
 import EnvName from './EnvName';
 import Footer from './Footer';
 import Header from './Header';
@@ -157,6 +158,7 @@ export default function AppManager(props) {
     <>
       {process.env.showName && <EnvName />}
       <Header onSignOut={handleSignOut} user={user} />
+      <Banner />
       <main>{children}</main>
       <Footer />
     </>

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -1,0 +1,49 @@
+import { makeStyles } from '@material-ui/styles';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import NotificationImportantIcon from '@material-ui/icons/NotificationImportant';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles(theme => ({
+  paper: {
+    padding: theme.spacing(2, 1, 1, 2),
+    backgroundColor: theme.palette.background.default,
+  },
+  avatar: {
+    backgroundColor: theme.palette.primary.main,
+  },
+}));
+
+function Banner() {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Paper elevation={0} className={classes.paper}>
+        <Grid container spacing={16} alignItems="space-between">
+          <Grid item>
+            <Avatar className={classes.avatar}>
+              <NotificationImportantIcon />
+            </Avatar>
+            <Typography>
+              If you have urgent questions here are some resources that New Jersey has made
+              available for residents.
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Button color="primary">learn more</Button>
+        </Grid>
+      </Paper>
+      <Divider />
+      <CssBaseline />
+    </>
+  );
+}
+
+export default Banner;

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -35,8 +35,7 @@ function Banner() {
             </Grid>
             <Grid item>
               <Typography>
-                If you have urgent questions here are some resources that New Jersey has made
-                available for residents.
+                Have general questions about COVID-19? Visit the NJ COVID-19 Information Hub.
               </Typography>
             </Grid>
             <Grid item>

--- a/components/Banner.js
+++ b/components/Banner.js
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/styles';
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
@@ -9,10 +8,12 @@ import NotificationImportantIcon from '@material-ui/icons/NotificationImportant'
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
+import ScaffoldContainer from './ScaffoldContainer';
+
 const useStyles = makeStyles(theme => ({
   paper: {
-    padding: theme.spacing(2, 1, 1, 2),
-    backgroundColor: theme.palette.background.default,
+    padding: theme.spacing(2, 1),
+    backgroundColor: '#f1f1f5',
   },
   avatar: {
     backgroundColor: theme.palette.primary.main,
@@ -24,24 +25,29 @@ function Banner() {
 
   return (
     <>
-      <Paper elevation={0} className={classes.paper}>
-        <Grid container spacing={16} alignItems="space-between">
-          <Grid item>
-            <Avatar className={classes.avatar}>
-              <NotificationImportantIcon />
-            </Avatar>
-            <Typography>
-              If you have urgent questions here are some resources that New Jersey has made
-              available for residents.
-            </Typography>
+      <Paper elevation={3} className={classes.paper}>
+        <ScaffoldContainer>
+          <Grid container spacing={2} alignItems="center">
+            <Grid item>
+              <Avatar className={classes.avatar}>
+                <NotificationImportantIcon />
+              </Avatar>
+            </Grid>
+            <Grid item>
+              <Typography>
+                If you have urgent questions here are some resources that New Jersey has made
+                available for residents.
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Button href="https://covid19.nj.gov/" target="_blank" color="primary" size="large">
+                <strong>learn more</strong>
+              </Button>
+            </Grid>
           </Grid>
-        </Grid>
-        <Grid item>
-          <Button color="primary">learn more</Button>
-        </Grid>
+        </ScaffoldContainer>
       </Paper>
       <Divider />
-      <CssBaseline />
     </>
   );
 }


### PR DESCRIPTION
Add persistent banner directing users to the COVID-19 information hub.

[Trello card](https://trello.com/c/nXnibvXx/202-direct-users-to-covid-19-information-hubl)

<img width="1314" alt="Screen Shot 2020-03-31 at 11 14 05 AM" src="https://user-images.githubusercontent.com/40243087/78042978-c6491180-7340-11ea-8dcd-bad34c4a73dc.png">
