### PR TITLE
#205 Feature: Hide Employment Outlook 

### DIFF
--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -18,7 +18,6 @@ import AirtablePropTypes from '../Airtable/PropTypes';
 import AssessmentCompleteDialog from './AssessmentCompleteDialog';
 import BackgroundHeader from '../BackgroundHeader';
 import CovidJobsAccess from './CovidJobsAccess';
-import EmploymentOutlookLauchpad from './EmploymentOutlookLauchpad';
 import FirebasePropTypes from '../Firebase/PropTypes';
 import ProgressFeed from './ProgressFeed';
 import ScaffoldContainer from '../ScaffoldContainer';
@@ -410,9 +409,12 @@ export default function Dashboard(props) {
           </Box>
           <Box className={classes.gridL} position="relative">
             <CovidJobsAccess />
-            <Box mt={8} style={{ position: 'relative' }}>
-              <EmploymentOutlookLauchpad />
-            </Box>
+            {
+              // Hide this feature since the data has become out of sync with the current climate
+              /* <Box mt={8} style={{ position: 'relative' }}>
+                      <EmploymentOutlookLauchpad />
+                </Box> */
+            }
           </Box>
           <Box className={classes.gridR}>
             <Card variant="outlined">


### PR DESCRIPTION
[Trello card](https://trello.com/c/p6Hu2Q0p/205-as-njcn-i-want-to-hide-the-employment-outlook-feature-in-response-to-covid-19)

Commented out the Employment Outlook launchpad