### PR TITLE
#173 Assessment headers polish - UI polish 

### DIFF
--- a/components/assessment/AssessmentSection.js
+++ b/components/assessment/AssessmentSection.js
@@ -5,22 +5,42 @@ import Typography from '@material-ui/core/Typography';
 
 import AirtablePropTypes from '../Airtable/PropTypes';
 import AssessmentSubsection from './AssessmentSubsection';
+import BackgroundHeader from '../BackgroundHeader';
 import FirebasePropTypes from '../Firebase/PropTypes';
+import ScaffoldContainer from '../ScaffoldContainer';
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    paddingTop: theme.spacing(1),
+  backgroundHeader: {
+    paddingBottom: theme.spacing(14),
+    background: `linear-gradient(to right bottom, #ffffff, ${theme.palette.background.secondaryHeader} 100%)`,
+  },
+  title: {
     maxWidth: 780,
     margin: '0 auto',
   },
   description: {
     marginTop: theme.spacing(2),
   },
+  container: {
+    marginTop: theme.spacing(-12),
+  },
+  questions: {
+    paddingTop: theme.spacing(1),
+    maxWidth: 780,
+    margin: '0 auto',
+  },
 }));
 
 export default function AssessmentSection(props) {
   const classes = useStyles();
-  const { assessmentSection, allAssessmentSubsections, onValidationChange, ...restProps } = props;
+  const {
+    assessmentSection,
+    allAssessmentSubsections,
+    onValidationChange,
+    currentStep,
+    totalSteps,
+    ...restProps
+  } = props;
   const assessmentSubsections = allAssessmentSubsections.filter(subsection =>
     assessmentSection.fields['Assessment Subsections'].includes(subsection.id)
   );
@@ -51,25 +71,40 @@ export default function AssessmentSection(props) {
   });
 
   return (
-    <div className={classes.root}>
-      <Typography component="h2" variant="h5">
-        {assessmentSection.fields.Name}
-      </Typography>
-      {assessmentSection.fields.Description && (
-        <Typography variant="body1" className={classes.description}>
-          {assessmentSection.fields.Description}
-        </Typography>
-      )}
-      <div data-intercom="assessment-section">
-        {assessmentSubsections.map((assessmentSubsection, index) => (
-          <AssessmentSubsection
-            key={assessmentSubsection.id}
-            assessmentSubsection={assessmentSubsection}
-            onValidationChange={handleValidationChange(index)}
-            {...restProps}
-          />
-        ))}
-      </div>
+    <div>
+      <BackgroundHeader className={classes.backgroundHeader}>
+        <ScaffoldContainer>
+          <div className={classes.title}>
+            <Typography variant="body2" gutterBottom>
+              Question {currentStep} of {totalSteps}
+            </Typography>
+            <Typography
+              component="h2"
+              variant="h5"
+              style={{ fontSize: '2rem', lineHeight: '2.5rem' }}
+            >
+              {assessmentSection.fields.Name}
+            </Typography>
+            {assessmentSection.fields.Description && (
+              <Typography variant="body1" className={classes.description}>
+                {assessmentSection.fields.Description}
+              </Typography>
+            )}
+          </div>
+        </ScaffoldContainer>
+      </BackgroundHeader>
+      <ScaffoldContainer className={classes.container}>
+        <div className={classes.questions} data-intercom="assessment-section">
+          {assessmentSubsections.map((assessmentSubsection, index) => (
+            <AssessmentSubsection
+              key={assessmentSubsection.id}
+              assessmentSubsection={assessmentSubsection}
+              onValidationChange={handleValidationChange(index)}
+              {...restProps}
+            />
+          ))}
+        </div>
+      </ScaffoldContainer>
     </div>
   );
 }
@@ -85,4 +120,6 @@ AssessmentSection.propTypes = {
   readOnly: PropTypes.bool.isRequired,
   reflectValidity: PropTypes.bool.isRequired,
   onValidationChange: PropTypes.func.isRequired,
+  currentStep: PropTypes.number.isRequired,
+  totalSteps: PropTypes.number.isRequired,
 };

--- a/components/assessment/AssessmentSectionList.js
+++ b/components/assessment/AssessmentSectionList.js
@@ -2,9 +2,6 @@ import { makeStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import Step from '@material-ui/core/Step';
-import StepLabel from '@material-ui/core/StepLabel';
-import Stepper from '@material-ui/core/Stepper';
 import Typography from '@material-ui/core/Typography';
 
 import AirtablePropTypes from '../Airtable/PropTypes';
@@ -12,30 +9,23 @@ import AssessmentSection from './AssessmentSection';
 import FirebasePropTypes from '../Firebase/PropTypes';
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    paddingTop: theme.spacing(2),
-  },
-  stepper: {
-    backgroundColor: 'inherit',
-    padding: 0,
-    marginBottom: theme.spacing(12),
-  },
-  stepLabel: {
-    [theme.breakpoints.down('xs')]: {
-      display: 'none',
-    },
-  },
   buttons: {
     display: 'flex',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    margin: theme.spacing(3, 0, 5),
+    margin: theme.spacing(3, 0, 8),
     marginLeft: 'auto',
     marginRight: 'auto', // TODO fix this grossness
     maxWidth: 780,
+    position: 'relative',
   },
   button: {
-    marginLeft: theme.spacing(1),
+    color: 'white',
+    backgroundColor: theme.palette.background.dark,
+    padding: theme.spacing(1, 8, 1, 8),
+    position: 'absolute',
+    right: 0,
+    top: 1,
   },
 }));
 
@@ -80,51 +70,41 @@ export default function AssessmentSectionList(props) {
   }, [activeStep, assessmentSections, onComplete]);
 
   return (
-    <div className={classes.root}>
-      <Stepper activeStep={activeStep} className={classes.stepper}>
-        {assessmentSections.map(section => (
-          <Step key={section.id}>
-            <StepLabel>
-              <span className={classes.stepLabel}>{section.fields['Short Name']}</span>
-            </StepLabel>
-          </Step>
-        ))}
-      </Stepper>
-
-      <div>
-        {activeStep !== assessmentSections.length && (
-          <div>
-            <AssessmentSection
-              assessmentSection={assessmentSections[activeStep]}
-              onValidationChange={handleValidationChange}
-              reflectValidity={reflectValidity}
-              {...restProps}
-            />
-            <div className={classes.buttons}>
-              {reflectValidity && !isActiveSectionValid && (
-                <Typography variant="subtitle2" color="error" className={classes.error}>
-                  Please complete all questions.
-                </Typography>
-              )}
-              {!!activeStep && (
-                <Button onClick={handleBack} className={classes.button}>
-                  Back
-                </Button>
-              )}
-              {(onComplete || activeStep < assessmentSections.length - 1) && (
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={handleNext}
-                  className={classes.button}
-                >
-                  {activeStep === assessmentSections.length - 1 ? 'Finish' : 'Next'}
-                </Button>
-              )}
-            </div>
+    <div>
+      {activeStep !== assessmentSections.length && (
+        <div>
+          <AssessmentSection
+            assessmentSection={assessmentSections[activeStep]}
+            currentStep={activeStep + 1}
+            totalSteps={assessmentSections.length}
+            onValidationChange={handleValidationChange}
+            reflectValidity={reflectValidity}
+            {...restProps}
+          />
+          <div className={classes.buttons}>
+            {reflectValidity && !isActiveSectionValid && (
+              <Typography variant="subtitle2" color="error" className={classes.error}>
+                Please complete all questions.
+              </Typography>
+            )}
+            {!!activeStep && (
+              <Button onClick={handleBack} style={{ textDecoration: 'underline' }}>
+                Back
+              </Button>
+            )}
+            {(onComplete || activeStep < assessmentSections.length - 1) && (
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleNext}
+                className={classes.button}
+              >
+                {activeStep === assessmentSections.length - 1 ? 'Finish' : 'Next'}
+              </Button>
+            )}
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/pages/assessment.js
+++ b/pages/assessment.js
@@ -1,7 +1,6 @@
 import { makeStyles } from '@material-ui/styles';
 import React, { useCallback, useState } from 'react';
 import Router from 'next/router';
-import Typography from '@material-ui/core/Typography';
 
 import { allPropsLoaded, englishList, fullyLoaded } from '../src/app-helper';
 import { logActivity } from '../components/activityInput/ActivityInputDialog';
@@ -10,20 +9,15 @@ import { useAuth, withAuthRequired } from '../components/Auth';
 import { useRecords } from '../components/Airtable';
 import { useUserSubcollection } from '../components/Firebase';
 import AssessmentSectionList from '../components/assessment/AssessmentSectionList';
-import BackgroundHeader from '../components/BackgroundHeader';
 import FullPageProgress from '../components/FullPageProgress';
-import ScaffoldContainer from '../components/ScaffoldContainer';
 import withTitle from '../components/withTitle';
 
 const useStyles = makeStyles(theme => ({
   root: {
     position: 'relative',
   },
-  backgroundHeader: {
-    paddingBottom: theme.spacing(12),
-  },
   assessmentContainer: {
-    marginTop: theme.spacing(-11),
+    marginTop: theme.spacing(-24),
   },
 }));
 
@@ -98,15 +92,8 @@ function Assessment() {
   }, []);
 
   return (
-    <div className={classes.root}>
-      <BackgroundHeader className={classes.backgroundHeader}>
-        <ScaffoldContainer>
-          <Typography ref={scrollToRef} component="h1" variant="h2" gutterBottom>
-            Hi, {user && user.firstName}
-          </Typography>
-        </ScaffoldContainer>
-      </BackgroundHeader>
-      <ScaffoldContainer className={classes.assessmentContainer}>
+    <div ref={scrollToRef} className={classes.root}>
+      <div>
         {fullyLoaded(user, allPropsLoaded(assessmentConfiguration), allQuestionResponses) &&
         !isFinished ? (
           <AssessmentSectionList
@@ -119,7 +106,7 @@ function Assessment() {
         ) : (
           <FullPageProgress />
         )}
-      </ScaffoldContainer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/FYiCgSKo/173-as-njcn-i-want-to-use-more-conversational-headers-per-onboarding-page-to-facilitate-a-more-human-onboarding-flow)
[Live Env](https://nj-career-network-dev4.firebaseapp.com/assessment/)

- Remove welcome message
- Remove stepper
- Change layout and style
<img width="1034" alt="Screen Shot 2020-03-25 at 9 49 26 AM" src="https://user-images.githubusercontent.com/40243087/78583406-cb0c3a80-7804-11ea-9fd3-f4905808299e.png">
