### PR TITLE
#174 Assessment questions polish - UI polish

### DIFF
--- a/components/ToggleButton.js
+++ b/components/ToggleButton.js
@@ -30,8 +30,10 @@ function ToggleButton(props) {
     value,
     handleChange,
     multiSelect,
+    disableDeselect,
     buttonClassName,
     buttonVariant,
+    selectedButtonVariant,
     containerClassName,
     disabledMessage,
   } = props;
@@ -46,7 +48,11 @@ function ToggleButton(props) {
   const hasPopover = v => disabledMessage && isDisabled(v);
 
   const handleUpdate = v => {
-    const newSelection = isSelected(v) ? removeSelected(v) : addSelected(v);
+    let newSelection = isSelected(v) ? removeSelected(v) : addSelected(v);
+    if (disableDeselect) {
+      // Only for Exclusive Selection, Multiple Selection not allowed
+      newSelection = v;
+    }
 
     handleChange(newSelection);
     setSelected(newSelection);
@@ -86,9 +92,11 @@ function ToggleButton(props) {
           onMouseLeave={handlePopoverClose}
         >
           <Button
-            style={{ height: '40px' }}
+            style={{ height: '44px' }}
             fullWidth
-            variant={buttonVariant}
+            variant={
+              selectedButtonVariant && isSelected(opt) ? selectedButtonVariant : buttonVariant
+            }
             onClick={() => handleUpdate(opt)}
             color={isSelected(opt) ? 'primary' : 'default'}
             disabled={isDisabled(opt)}
@@ -126,17 +134,21 @@ ToggleButton.propTypes = {
   value: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.string]).isRequired,
   handleChange: PropTypes.func.isRequired,
   multiSelect: PropTypes.bool,
+  disableDeselect: PropTypes.bool,
   buttonClassName: PropTypes.string,
   containerClassName: PropTypes.string,
   buttonVariant: PropTypes.string,
+  selectedButtonVariant: PropTypes.string,
   disabledMessage: PropTypes.string,
 };
 
 ToggleButton.defaultProps = {
   disabledOptions: [],
   multiSelect: false,
+  disableDeselect: false,
   buttonClassName: undefined,
   buttonVariant: 'contained',
+  selectedButtonVariant: undefined,
   containerClassName: undefined,
   disabledMessage: '',
 };

--- a/components/assessment/AssessmentSubsection.js
+++ b/components/assessment/AssessmentSubsection.js
@@ -12,9 +12,9 @@ import FirebasePropTypes from '../Firebase/PropTypes';
 const useStyles = makeStyles(theme => ({
   root: {
     marginTop: theme.spacing(5),
-    padding: theme.spacing(3, 4, 3),
+    padding: theme.spacing(3, 5, 3),
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing(3, 5, 3),
+      padding: theme.spacing(3, 10, 3),
     },
   },
   title: {

--- a/components/assessment/Question/BinaryQuestion.js
+++ b/components/assessment/Question/BinaryQuestion.js
@@ -1,16 +1,29 @@
 import { makeStyles } from '@material-ui/styles';
+import Card from '@material-ui/core/Card';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import AirtablePropTypes from '../../Airtable/PropTypes';
 
 const useStyles = makeStyles(theme => ({
+  label: {
+    fontWeight: 500,
+  },
   formHelperText: {
     margin: theme.spacing(0, 0, 2, 4),
     ...theme.typography.helperText,
+  },
+  card: {
+    padding: theme.spacing(1, 2),
+    marginBottom: theme.spacing(1),
+  },
+  cardSelected: {
+    padding: theme.spacing(1, 2),
+    marginBottom: theme.spacing(1),
+    backgroundColor: 'rgba(24, 129, 197, 0.07)',
   },
 }));
 
@@ -18,11 +31,17 @@ export default function BinaryQuestion(props) {
   const { onChange, onValidationChange, question, value } = props;
   const checkbox = useRef(null);
   const classes = useStyles();
+  const [checked, setChecked] = useState(false);
 
   useEffect(() => {
     // hack: persist check box values when they're first rendered,
     // otherwise we don't get "false" recorded on checkboxes never touched.
     onChange(checkbox.current.checked);
+    if (checkbox.current.checked) {
+      setChecked(true);
+    } else {
+      setChecked(false);
+    }
   }, [onChange]);
 
   useEffect(() => {
@@ -31,8 +50,11 @@ export default function BinaryQuestion(props) {
   }, [onValidationChange]);
 
   return (
-    <>
+    <Card className={checked ? classes.cardSelected : classes.card} variant="outlined">
       <FormControlLabel
+        classes={{
+          label: classes.label,
+        }}
         disabled={question.fields.Disabled}
         label={question.fields.Label}
         control={
@@ -50,7 +72,7 @@ export default function BinaryQuestion(props) {
           {question.fields['Helper Text']}
         </FormHelperText>
       )}
-    </>
+    </Card>
   );
 }
 

--- a/components/assessment/Question/OptionQuestion/OptionQuestion.js
+++ b/components/assessment/Question/OptionQuestion/OptionQuestion.js
@@ -1,18 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import DropdownQuestion from './DropdownQuestion';
-import RadiosQuestion from './RadiosQuestion';
+import ToggleButtonQuestion from './ToggleButtonQuestion';
 
 import AirtablePropTypes from '../../../Airtable/PropTypes';
 
 export default function OptionQuestion(props) {
-  const { isInGroup, responseOptionsControl, ...restProps } = props;
+  const { isInGroup, isLastInGroup, responseOptionsControl, ...restProps } = props;
 
   switch (responseOptionsControl) {
     case 'Dropdown':
-      return <DropdownQuestion {...restProps} horizontalOnDesktop={isInGroup} />;
+      return <ToggleButtonQuestion {...restProps} isLastInGroup={isLastInGroup} />;
     case 'Radios':
-      return <RadiosQuestion {...restProps} />;
+      return <ToggleButtonQuestion useFullWidthButton {...restProps} />;
     default:
       return null;
   }
@@ -20,6 +19,7 @@ export default function OptionQuestion(props) {
 
 OptionQuestion.propTypes = {
   isInGroup: PropTypes.bool,
+  isLastInGroup: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onValidationChange: PropTypes.func.isRequired,
   question: AirtablePropTypes.question.isRequired,
@@ -31,6 +31,7 @@ OptionQuestion.propTypes = {
 
 OptionQuestion.defaultProps = {
   isInGroup: false,
+  isLastInGroup: false,
   reflectValidity: false,
   value: null,
 };

--- a/components/assessment/Question/OptionQuestion/ToggleButtonQuestion.js
+++ b/components/assessment/Question/OptionQuestion/ToggleButtonQuestion.js
@@ -1,0 +1,117 @@
+import { makeStyles } from '@material-ui/styles';
+import Divider from '@material-ui/core/Divider';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormLabel from '@material-ui/core/FormLabel';
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
+import Typography from '@material-ui/core/Typography';
+
+import AirtablePropTypes from '../../../Airtable/PropTypes';
+import ToggleButton from '../../../ToggleButton';
+
+const useStyles = makeStyles(theme => ({
+  formControl: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(4),
+    width: '100%',
+  },
+  button: {
+    width: '47%',
+    height: theme.spacing(5.5),
+    marginBottom: theme.spacing(2),
+    margin: 'auto',
+  },
+  fullWidthButton: {
+    width: '100%',
+    height: theme.spacing(5.5),
+    marginBottom: theme.spacing(2),
+  },
+  helperText: {
+    ...theme.typography.helperText,
+    marginBottom: theme.spacing(3),
+  },
+  divider: {
+    margin: theme.spacing(2, 0, 6),
+  },
+  largeLabel: {
+    fontSize: '1.25rem',
+    fontWeight: 500,
+    color: '#0c4163',
+  },
+}));
+
+export default function ToggleButtonQuestion(props) {
+  const classes = useStyles();
+  const {
+    onChange,
+    onValidationChange,
+    optional,
+    question,
+    reflectValidity,
+    responseOptions,
+    value,
+    useFullWidthButton,
+    isLastInGroup,
+  } = props;
+
+  const helperText = question.fields['Helper Text'];
+  const isValid = optional || !!value || value === 0;
+  const reflectError = reflectValidity && !isValid;
+
+  useEffect(() => {
+    onValidationChange(isValid);
+  }, [isValid, onValidationChange]);
+
+  const HelperText = () => (
+    <FormHelperText className={classes.helperText}>{helperText}</FormHelperText>
+  );
+
+  const options = responseOptions.map(option => option.fields.Name);
+
+  return (
+    <div>
+      <FormControl className={classes.formControl}>
+        <FormLabel component="legend" error={reflectError}>
+          <Typography
+            variant="body2"
+            className={helperText ? classes.largeLabel : null}
+            gutterBottom
+          >
+            {question.fields.Label}
+          </Typography>
+        </FormLabel>
+        {helperText && <HelperText />}
+        <ToggleButton
+          options={options}
+          value={value}
+          handleChange={onChange}
+          buttonVariant="outlined"
+          selectedButtonVariant="contained"
+          buttonClassName={useFullWidthButton ? classes.fullWidthButton : classes.button}
+          disableDeselect
+        />
+      </FormControl>
+      {helperText && !isLastInGroup && <Divider className={classes.divider} />}
+    </div>
+  );
+}
+
+ToggleButtonQuestion.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  onValidationChange: PropTypes.func.isRequired,
+  optional: PropTypes.bool.isRequired,
+  question: AirtablePropTypes.question.isRequired,
+  reflectValidity: PropTypes.bool,
+  responseOptions: AirtablePropTypes.questionResponseOptions.isRequired,
+  value: PropTypes.string,
+  useFullWidthButton: PropTypes.bool,
+  isLastInGroup: PropTypes.bool,
+};
+
+ToggleButtonQuestion.defaultProps = {
+  reflectValidity: false,
+  value: null,
+  useFullWidthButton: false,
+  isLastInGroup: false,
+};

--- a/components/assessment/Question/Question.js
+++ b/components/assessment/Question/Question.js
@@ -46,6 +46,7 @@ function Question(props) {
     allQuestionResponseOptions,
     allQuestionResponses,
     isInGroup,
+    isLastInGroup,
     onValidationChange,
     optional,
     readOnly,
@@ -177,6 +178,7 @@ function Question(props) {
     onChange: _localValue => setLocalValue(_localValue),
     onChangeCommitted: _value => setValue(_value),
     value: localValue ? parseFloat(localValue) : undefined,
+    isLastInGroup,
   };
 
   switch (responseType) {
@@ -204,11 +206,14 @@ function Question(props) {
       return <BinaryQuestion {...discreteQuestionProps} />;
     case 'Option':
       return (
-        <OptionQuestion
-          {...discreteQuestionProps}
-          responseOptions={responseOptions}
-          responseOptionsControl={responseOptionsControl}
-        />
+        <>
+          <OptionQuestion
+            {...discreteQuestionProps}
+            responseOptions={responseOptions}
+            responseOptionsControl={responseOptionsControl}
+            isLastInGroup={isLastInGroup}
+          />
+        </>
       );
     case 'Link':
       return null; // TODO: implement a LinkQuestion component
@@ -239,6 +244,7 @@ Question.propTypes = {
   allQuestionResponseOptions: AirtablePropTypes.questionResponseOptions.isRequired,
   allQuestionResponses: FirebasePropTypes.querySnapshot.isRequired,
   isInGroup: PropTypes.bool,
+  isLastInGroup: PropTypes.bool,
   onValidationChange: PropTypes.func.isRequired,
   optional: PropTypes.bool.isRequired,
   readOnly: PropTypes.bool.isRequired,
@@ -247,4 +253,5 @@ Question.propTypes = {
 
 Question.defaultProps = {
   isInGroup: false,
+  isLastInGroup: false,
 };

--- a/components/assessment/Question/SliderQuestion.js
+++ b/components/assessment/Question/SliderQuestion.js
@@ -1,19 +1,24 @@
 import { makeStyles, withStyles } from '@material-ui/styles';
+import Divider from '@material-ui/core/Divider';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import FormLabel from '@material-ui/core/FormLabel';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import Slider from '@material-ui/core/Slider';
+import Typography from '@material-ui/core/Typography';
 
 import AirtablePropTypes from '../../Airtable/PropTypes';
 
 const useStyles = makeStyles(theme => ({
   root: {
-    marginBottom: theme.spacing(3),
+    marginBottom: theme.spacing(6),
   },
   helperText: {
-    marginBottom: theme.spacing(1),
     ...theme.typography.helperText,
+    marginBottom: theme.spacing(3),
+  },
+  divider: {
+    margin: theme.spacing(6, 0, 2),
   },
 }));
 
@@ -63,13 +68,14 @@ export default function SliderQuestion(props) {
     max,
     step,
     value,
+    isLastInGroup,
   } = props;
 
   const helperText = question.fields['Helper Text'];
 
   const marks = [];
   for (let n = min; n <= max; n += step) {
-    const label = n === min || n === max ? n : null;
+    const label = n === min || n === max ? `${n} Hours` : null;
     marks.push({ value: n, label });
   }
 
@@ -83,9 +89,12 @@ export default function SliderQuestion(props) {
 
   return (
     <div className={classes.root}>
-      <FormLabel component="legend">{question.fields.Label}</FormLabel>
+      <FormLabel component="legend">
+        <Typography variant="h6" style={{ color: '#0c4163' }}>
+          {question.fields.Label}
+        </Typography>
+      </FormLabel>
       {helperText && <FormHelperText className={classes.helperText}>{helperText}</FormHelperText>}
-
       <StyledSlider
         aria-label={question.fields.Label}
         aria-valuetext={`${value}`}
@@ -99,6 +108,7 @@ export default function SliderQuestion(props) {
         value={value}
         valueLabelDisplay="auto"
       />
+      {!isLastInGroup && <Divider className={classes.divider} />}
     </div>
   );
 }
@@ -112,8 +122,10 @@ SliderQuestion.propTypes = {
   step: PropTypes.number.isRequired,
   value: PropTypes.number,
   onValidationChange: PropTypes.func.isRequired,
+  isLastInGroup: PropTypes.bool,
 };
 
 SliderQuestion.defaultProps = {
   value: 0,
+  isLastInGroup: false,
 };

--- a/components/assessment/Question/TextQuestion.js
+++ b/components/assessment/Question/TextQuestion.js
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/styles';
+import InfoIcon from '@material-ui/icons/Info';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import TextField from '@material-ui/core/TextField';
@@ -8,10 +9,18 @@ import AirtablePropTypes from '../../Airtable/PropTypes';
 // eslint-disable-next-line no-unused-vars
 const useStyles = makeStyles(theme => ({
   textField: {
+    marginTop: theme.spacing(1),
     marginBottom: theme.spacing(3),
     fontWeight: 500,
   },
-  helperText: theme.typography.helperText,
+  helperText: {
+    display: 'flex',
+    fontSize: '0.75rem',
+    lineHeight: '1rem',
+    backgroundColor: theme.palette.background.header,
+    margin: theme.spacing(0.5, 0),
+    padding: theme.spacing(1),
+  },
 }));
 
 export default function TextQuestion(props) {
@@ -30,28 +39,38 @@ export default function TextQuestion(props) {
   } = props;
   const isValid = optional || !!value;
   const reflectError = reflectValidity && !isValid;
+  const helperText = question.fields['Helper Text'];
 
   useEffect(() => {
     onValidationChange(isValid);
   }, [isValid, onValidationChange]);
 
   return (
-    <TextField
-      id={question.id}
-      disabled={question.fields.Disabled}
-      label={question.fields.Label}
-      className={classes.textField}
-      onBlur={e => onBlur(e.target.value)}
-      onChange={e => onChange(e.target.value)}
-      margin="normal"
-      helperText={question.fields['Helper Text']}
-      fullWidth
-      inputProps={inputProps}
-      FormHelperTextProps={{ classes: { root: classes.helperText } }}
-      error={reflectError}
-      value={value}
-      {...restProps}
-    />
+    <>
+      <span>{question.fields.Label}</span>
+      <TextField
+        id={question.id}
+        disabled={question.fields.Disabled}
+        className={classes.textField}
+        onBlur={e => onBlur(e.target.value)}
+        onChange={e => onChange(e.target.value)}
+        variant="outlined"
+        helperText={
+          helperText && (
+            <>
+              <InfoIcon color="primary" style={{ fontSize: '1.2rem', marginRight: '0.5rem' }} />
+              <span>{helperText}</span>
+            </>
+          )
+        }
+        fullWidth
+        inputProps={inputProps}
+        FormHelperTextProps={{ classes: { root: classes.helperText } }}
+        error={reflectError}
+        value={value}
+        {...restProps}
+      />
+    </>
   );
 }
 

--- a/components/assessment/QuestionGroup.js
+++ b/components/assessment/QuestionGroup.js
@@ -18,7 +18,6 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
   },
   label: {
-    fontWeight: 500,
     marginBottom: theme.spacing(2),
   },
   footerText: {
@@ -62,10 +61,6 @@ export default function QuestionGroup(props) {
   return (
     <div className={classes.root}>
       <FormControl component="fieldset" className={classes.formControl}>
-        <Typography component="legend" variant="body1" className={classes.label}>
-          {questionGroup.fields.Label}
-        </Typography>
-
         <FormGroup>
           {questions.map((question, index) => (
             <Question
@@ -74,6 +69,7 @@ export default function QuestionGroup(props) {
               onValidationChange={handleValidationChange(index)}
               {...restProps}
               isInGroup
+              isLastInGroup={index === questions.length - 1}
             />
           ))}
         </FormGroup>


### PR DESCRIPTION
[Trello card](https://trello.com/c/GbqveXEk/174-1-of-3-as-njcn-i-want-to-use-more-humanized-question-styling-to-facilitate-a-more-human-onboarding-flow)
[Live Env](https://nj-career-network-dev3.firebaseapp.com/assessment/)

- Changed text fields to be outlined
- Update helper text style 
- Change the options questions (Radio and Dropdown) to be toggle buttons
- Add dividers and special styling in Document and Time pages (see the screenshot below)

<img width="863" alt="Screen Shot 2020-04-07 at 11 57 51 AM" src="https://user-images.githubusercontent.com/40243087/78691786-08390100-78c7-11ea-9b9d-4ac98a20729d.png">

