### PR TITLE
#227 Add Profile Card to Dashboard

### DIFF
--- a/components/dashboard/CovidJobsAccess.js
+++ b/components/dashboard/CovidJobsAccess.js
@@ -8,6 +8,9 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(theme => ({
+  wrapper: {
+    position: 'relative',
+  },
   iconContainer: {
     position: 'absolute',
     top: theme.spacing(-3),
@@ -38,7 +41,7 @@ function CovidJobsAccess() {
   const classes = useStyles();
 
   return (
-    <>
+    <div className={classes.wrapper}>
       <div className={classes.iconContainer}>
         <FlagIcon fontSize="large" />
       </div>
@@ -64,7 +67,7 @@ function CovidJobsAccess() {
           </Button>
         </CardActions>
       </Card>
-    </>
+    </div>
   );
 }
 

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -1,5 +1,6 @@
 import { isToday } from 'date-fns';
 import { makeStyles } from '@material-ui/styles';
+import { Flags } from 'react-feature-flags';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
@@ -27,6 +28,7 @@ import SentimentTracker from './SentimentTracker/SentimentTracker';
 import TaskList from './TaskList';
 import TimeDistanceParser from '../../src/time-distance-parser';
 import UpcomingInterviewDialog from './UpcomingInterviewDialog/UpcomingInterviewDialog';
+import UserProfileCard from './UserProfileCard';
 
 const TASK_COUNT_LIMIT = 3;
 const ROW_GAP = 2;
@@ -400,6 +402,11 @@ export default function Dashboard(props) {
             />
           </Box>
           <Box className={classes.gridL} position="relative">
+            <Flags authorizedFlags={['userProfile']}>
+              <Box mb={5}>
+                <UserProfileCard user={user} />
+              </Box>
+            </Flags>
             <CovidJobsAccess />
             {
               // Hide this feature since the data has become out of sync with the current climate

--- a/components/dashboard/UserProfileCard.js
+++ b/components/dashboard/UserProfileCard.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import Avatar from '@material-ui/core/Avatar';
+import Button from '@material-ui/core/Button';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Grid from '@material-ui/core/Grid';
+import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
+import PersonIcon from '@material-ui/icons/Person';
+import NextLink from 'next/link';
+import UserClass from '../../src/User';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    padding: theme.spacing(2),
+  },
+  cardHeader: {
+    marginBottom: theme.spacing(1),
+  },
+  cardContent: {
+    padding: theme.spacing(1),
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    border: `4px solid ${theme.palette.primary.main}`,
+  },
+  lightButtonRoot: {
+    backgroundColor: 'RGBA(24,129,197,0.06)',
+  },
+  lightButtonLabel: {
+    color: '#1881C5',
+  },
+}));
+
+function UserProfileCard({ user }) {
+  const classes = useStyles();
+  const { photoURL, displayName } = user;
+
+  return (
+    <>
+      <Card className={classes.card} variant="outlined">
+        <CardContent className={classes.cardContent}>
+          <Grid container alignItems="center" spacing={1} className={classes.cardHeader}>
+            <Grid item>
+              <Avatar src={photoURL} alt={displayName} className={classes.avatar}>
+                <PersonIcon />
+              </Avatar>
+            </Grid>
+            <Grid item>
+              <Typography variant="h6" gutterBottom>
+                {user.displayName}
+              </Typography>
+            </Grid>
+          </Grid>
+          <Divider variant="fullWidth" />
+        </CardContent>
+        <CardActions disableSpacing>
+          <NextLink href="/profile">
+            <Button
+              fullWidth
+              variant="contained"
+              size="large"
+              classes={{ root: classes.lightButtonRoot, label: classes.lightButtonLabel }}
+            >
+              View My Profile
+            </Button>
+          </NextLink>
+        </CardActions>
+      </Card>
+    </>
+  );
+}
+
+UserProfileCard.propTypes = {
+  user: PropTypes.instanceOf(UserClass).isRequired,
+};
+
+export default UserProfileCard;

--- a/components/profile/Profile.js
+++ b/components/profile/Profile.js
@@ -1,0 +1,27 @@
+import { makeStyles } from '@material-ui/styles';
+import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+import ScaffoldContainer from '../ScaffoldContainer';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    position: 'relative',
+  },
+}));
+
+function Profile() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <ScaffoldContainer>
+        <Typography component="h1" variant="h2" gutterBottom>
+          Profile
+        </Typography>
+      </ScaffoldContainer>
+    </div>
+  );
+}
+
+export default Profile;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -30,7 +30,12 @@ Router.events.on('routeChangeComplete', () => {
   window.Intercom('update');
 });
 
-const featureFlags = [{}];
+const featureFlags = [
+  {
+    name: 'userProfile',
+    isActive: false,
+  },
+];
 
 Sentry.init({
   environment: process.env.name,

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { fullyLoaded } from '../src/app-helper';
+import { useAuth, withAuthRequired } from '../components/Auth';
+import Profile from '../components/profile/Profile';
+import FullPageProgress from '../components/FullPageProgress';
+import withTitle from '../components/withTitle';
+
+function ProfilePage() {
+  const { user } = useAuth();
+
+  return fullyLoaded(user) ? <Profile /> : <FullPageProgress />;
+}
+
+export default withAuthRequired(withTitle(ProfilePage, 'Profile'));


### PR DESCRIPTION
[Trello Card](https://trello.com/c/FkdlgEuZ/227-as-a-user-i-want-to-be-able-to-access-my-profile-page-from-the-dashboard)
[Live Env](https://nj-career-network-dev5.firebaseapp.com/)

• Create User Profile Card component that displays avatar and button linking to new page
• Add User Profile Card to the Dashboard page
• Add Profile page to site routes (`/profile`)

<img width="1416" alt="Screen Shot 2020-05-08 at 12 39 53 PM" src="https://user-images.githubusercontent.com/42354755/81427650-14fc7f00-9129-11ea-9ad5-96a3b7e7df61.png">