### PR TITLE
Add edit mode to profile page #231 #232

### DIFF
--- a/components/profile/GoalEditCard.js
+++ b/components/profile/GoalEditCard.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    padding: theme.spacing(1),
+  },
+  title: {
+    color: theme.palette.background.dark,
+    marginBottom: theme.spacing(2),
+  },
+  textField: {
+    marginTop: theme.spacing(2),
+  },
+}));
+
+function GoalEditCard({ value }) {
+  const classes = useStyles();
+
+  return (
+    <>
+      <Card className={classes.card} variant="outlined">
+        <CardContent>
+          <Typography className={classes.title} component="h2" variant="h6">
+            My Goal
+          </Typography>
+          <Typography variant="body2">
+            You can update your goal from your profile as your job search evolves. Your answer won’t
+            be shown to others.
+          </Typography>
+          <TextField
+            variant="outlined"
+            value={value}
+            multiline
+            rows={6}
+            fullWidth
+            className={classes.textField}
+            inputProps={{ maxLength: 80 }}
+          />
+        </CardContent>
+      </Card>
+    </>
+  );
+}
+
+GoalEditCard.propTypes = {
+  value: PropTypes.string.isRequired,
+};
+
+export default GoalEditCard;

--- a/components/profile/GoalEditCard.js
+++ b/components/profile/GoalEditCard.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function GoalEditCard({ value }) {
+function GoalEditCard({ value, onChange }) {
   const classes = useStyles();
 
   return (
@@ -36,11 +36,11 @@ function GoalEditCard({ value }) {
           <TextField
             variant="outlined"
             value={value}
+            onChange={onChange}
             multiline
             rows={6}
             fullWidth
             className={classes.textField}
-            inputProps={{ maxLength: 80 }}
           />
         </CardContent>
       </Card>
@@ -50,6 +50,7 @@ function GoalEditCard({ value }) {
 
 GoalEditCard.propTypes = {
   value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default GoalEditCard;

--- a/components/profile/Profile.js
+++ b/components/profile/Profile.js
@@ -3,7 +3,7 @@ import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { useAuth } from '../Auth';
@@ -11,6 +11,7 @@ import ProfileItemCard from './ProfileItemCard';
 import UserProfileCard from './UserProfileCard';
 import ScaffoldContainer from '../ScaffoldContainer';
 import Goal from './Goal';
+import GoalEditCard from './GoalEditCard';
 
 const ROW_GAP = 2;
 const COL_GAP = 2;
@@ -85,29 +86,75 @@ const PROFILE_ITEMS = [
   },
 ];
 
+const profile = {
+  phone: '68293739823',
+  goal: `I will land a job as an Analyst with a financial institution by the end of this
+  year. To accomplish this goal, I will improve my skills with Microsoft Excel. I will
+  connect with other Analysts in my network to learn about their career paths.`,
+  educationItems: [
+    {
+      school: 'Trenton Central Highschool',
+      'study-field': 'General Education',
+      'education-start-year': 2011,
+      'education-end-year': 2015,
+    },
+  ],
+  employmentItems: [
+    {
+      org: 'Nordstrom',
+      title: 'Retail Asscociate',
+      'start-year': 2017,
+      'start-month': 'January',
+      'end-year': 2020,
+      'end-month': 'March',
+    },
+    {
+      org: "Trader Joe's",
+      title: 'Retail Asscociate',
+      'start-year': 2015,
+      'start-month': 'October',
+      'end-year': 2017,
+      'end-month': 'August',
+    },
+  ],
+};
+
 function Profile({ profileData }) {
   const classes = useStyles();
   const { user } = useAuth();
   const { phone } = profileData;
+  const [editMode, setEditMode] = useState(false);
 
   return (
     <div className={classes.root}>
-      <Goal goal={profileData.goal} />
+      {!editMode && <Goal goal={profile.goal} />}
       <ScaffoldContainer>
+        {console.log(profileData)}
         <Box className={classes.grid} mb={10}>
           <Box className={classes.gridC}>
+            {editMode && (
+              <Box mb={3}>
+                <GoalEditCard value={profile.goal} />
+              </Box>
+            )}
             {PROFILE_ITEMS.map(item => (
               <Box mb={3}>
                 <ProfileItemCard
                   title={item.title}
-                  items={profileData[item.value]}
+                  items={profile[item.value]}
                   type={item.value}
+                  editMode={editMode}
                 />
               </Box>
             ))}
           </Box>
           <Box className={classes.gridL} position="relative">
-            <UserProfileCard user={user} phoneNumber={phone} />
+            <UserProfileCard
+              user={user}
+              phoneNumber={phone}
+              editMode={editMode}
+              onButtonClick={() => (editMode ? setEditMode(false) : setEditMode(true))}
+            />
           </Box>
           <Box className={classes.gridR}>
             <Card variant="outlined">

--- a/components/profile/Profile.js
+++ b/components/profile/Profile.js
@@ -4,7 +4,7 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import firebase from 'firebase/app';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { useAuth } from '../Auth';
@@ -91,16 +91,20 @@ function Profile({ profileData }) {
   const classes = useStyles();
   const { user, userDocRef } = useAuth();
   const [editMode, setEditMode] = useState(false);
-  const [values, setValues] = useState(profileData);
+  const [values, setValues] = useState({});
 
   const handleSave = () => {
     setEditMode(false);
     const data = {
-      ...values,
+      goal: values.goal,
       lastUpdateTimestamp: firebase.firestore.FieldValue.serverTimestamp(),
     };
     userDocRef.set({ userProfile: data }, { merge: true });
   };
+
+  useEffect(() => {
+    setValues({ goal: profileData.goal });
+  }, [profileData]);
 
   return (
     <div className={classes.root}>

--- a/components/profile/Profile.js
+++ b/components/profile/Profile.js
@@ -2,16 +2,17 @@ import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
+import firebase from 'firebase/app';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { useAuth } from '../Auth';
-import ProfileItemCard from './ProfileItemCard';
-import UserProfileCard from './UserProfileCard';
-import ScaffoldContainer from '../ScaffoldContainer';
 import Goal from './Goal';
 import GoalEditCard from './GoalEditCard';
+import ProfileItemCard from './ProfileItemCard';
+import ScaffoldContainer from '../ScaffoldContainer';
+import UserProfileCard from './UserProfileCard';
 
 const ROW_GAP = 2;
 const COL_GAP = 2;
@@ -88,19 +89,31 @@ const PROFILE_ITEMS = [
 
 function Profile({ profileData }) {
   const classes = useStyles();
-  const { user } = useAuth();
-  const { phone } = profileData;
+  const { user, userDocRef } = useAuth();
   const [editMode, setEditMode] = useState(false);
+  const [values, setValues] = useState(profileData);
+
+  const handleSave = () => {
+    setEditMode(false);
+    const data = {
+      ...values,
+      lastUpdateTimestamp: firebase.firestore.FieldValue.serverTimestamp(),
+    };
+    userDocRef.set({ userProfile: data }, { merge: true });
+  };
 
   return (
     <div className={classes.root}>
-      {!editMode && <Goal goal={profileData.goal} />}
+      {!editMode && <Goal goal={values.goal} />}
       <ScaffoldContainer>
         <Box className={classes.grid} mb={10}>
           <Box className={classes.gridC}>
             {editMode && (
               <Box mb={3}>
-                <GoalEditCard value={profileData.goal} />
+                <GoalEditCard
+                  value={values.goal}
+                  onChange={e => setValues({ ...values, goal: e.target.value })}
+                />
               </Box>
             )}
             {PROFILE_ITEMS.map(item => (
@@ -117,9 +130,9 @@ function Profile({ profileData }) {
           <Box className={classes.gridL} position="relative">
             <UserProfileCard
               user={user}
-              phoneNumber={phone}
+              phoneNumber={profileData.phone}
               editMode={editMode}
-              onButtonClick={() => (editMode ? setEditMode(false) : setEditMode(true))}
+              onButtonClick={() => (editMode ? handleSave() : setEditMode(true))}
             />
           </Box>
           <Box className={classes.gridR}>

--- a/components/profile/Profile.js
+++ b/components/profile/Profile.js
@@ -86,39 +86,6 @@ const PROFILE_ITEMS = [
   },
 ];
 
-const profile = {
-  phone: '68293739823',
-  goal: `I will land a job as an Analyst with a financial institution by the end of this
-  year. To accomplish this goal, I will improve my skills with Microsoft Excel. I will
-  connect with other Analysts in my network to learn about their career paths.`,
-  educationItems: [
-    {
-      school: 'Trenton Central Highschool',
-      'study-field': 'General Education',
-      'education-start-year': 2011,
-      'education-end-year': 2015,
-    },
-  ],
-  employmentItems: [
-    {
-      org: 'Nordstrom',
-      title: 'Retail Asscociate',
-      'start-year': 2017,
-      'start-month': 'January',
-      'end-year': 2020,
-      'end-month': 'March',
-    },
-    {
-      org: "Trader Joe's",
-      title: 'Retail Asscociate',
-      'start-year': 2015,
-      'start-month': 'October',
-      'end-year': 2017,
-      'end-month': 'August',
-    },
-  ],
-};
-
 function Profile({ profileData }) {
   const classes = useStyles();
   const { user } = useAuth();
@@ -127,21 +94,20 @@ function Profile({ profileData }) {
 
   return (
     <div className={classes.root}>
-      {!editMode && <Goal goal={profile.goal} />}
+      {!editMode && <Goal goal={profileData.goal} />}
       <ScaffoldContainer>
-        {console.log(profileData)}
         <Box className={classes.grid} mb={10}>
           <Box className={classes.gridC}>
             {editMode && (
               <Box mb={3}>
-                <GoalEditCard value={profile.goal} />
+                <GoalEditCard value={profileData.goal} />
               </Box>
             )}
             {PROFILE_ITEMS.map(item => (
               <Box mb={3}>
                 <ProfileItemCard
                   title={item.title}
-                  items={profile[item.value]}
+                  items={profileData[item.value]}
                   type={item.value}
                   editMode={editMode}
                 />

--- a/components/profile/ProfileItemCard.js
+++ b/components/profile/ProfileItemCard.js
@@ -2,9 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles(theme => ({
@@ -15,9 +18,18 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.background.dark,
     marginBottom: theme.spacing(2),
   },
+  button: {
+    color: 'white',
+    backgroundColor: theme.palette.background.dark,
+    padding: theme.spacing(1, 8, 1, 8),
+  },
+  itemCard: {
+    padding: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
 }));
 
-function ProfileItemCard({ title, items, type }) {
+function ProfileItemCard({ title, items, type, editMode }) {
   const classes = useStyles();
   const experience = item => {
     if (type === 'educationItems') {
@@ -40,18 +52,46 @@ function ProfileItemCard({ title, items, type }) {
           <Typography className={classes.title} component="h2" variant="h6">
             {title}
           </Typography>
-          <Divider variant="fullWidth" />
+          {!editMode && <Divider variant="fullWidth" />}
           {items.map(item => (
-            <Box mt={2}>
-              <Typography variant="body1" gutterBottom>
-                {experience(item)}
-              </Typography>
-              <Typography variant="body2" gutterBottom>
-                {dates(item)}
-              </Typography>
-            </Box>
+            <>
+              {!editMode && (
+                <Box mt={2}>
+                  <Typography variant="body1" gutterBottom>
+                    {experience(item)}
+                  </Typography>
+                  <Typography variant="body2" gutterBottom>
+                    {dates(item)}
+                  </Typography>
+                </Box>
+              )}
+              {editMode && (
+                <Card className={classes.itemCard} variant="outlined">
+                  <Grid container alignItems="center" direction="row" justify="space-between">
+                    <Grid item>
+                      <Typography variant="body1" gutterBottom>
+                        {experience(item)}
+                      </Typography>
+                      <Typography variant="body2" gutterBottom>
+                        {dates(item)}
+                      </Typography>
+                    </Grid>
+                    <Grid item>
+                      <Button variant="contained">EDIT</Button>
+                    </Grid>
+                  </Grid>
+                </Card>
+              )}
+            </>
           ))}
         </CardContent>
+        <CardActions disableSpacing>
+          {editMode && (
+            <Button className={classes.button} variant="contained" fullWidth>
+              Add {title}
+            </Button>
+          )}
+        </CardActions>
       </Card>
     </>
   );
@@ -61,6 +101,7 @@ ProfileItemCard.propTypes = {
   title: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   type: PropTypes.string.isRequired,
+  editMode: PropTypes.bool.isRequired,
 };
 
 export default ProfileItemCard;

--- a/components/profile/UserProfileCard.js
+++ b/components/profile/UserProfileCard.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import Avatar from '@material-ui/core/Avatar';
 import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import Divider from '@material-ui/core/Divider';
 import EmailIcon from '@material-ui/icons/Email';
@@ -31,9 +33,15 @@ const useStyles = makeStyles(theme => ({
   info: {
     marginLeft: theme.spacing(1),
   },
+  lightButtonRoot: {
+    backgroundColor: 'RGBA(24,129,197,0.06)',
+  },
+  lightButtonLabel: {
+    color: '#1881C5',
+  },
 }));
 
-function UserProfileCard({ user, phoneNumber }) {
+function UserProfileCard({ user, phoneNumber, onButtonClick, editMode }) {
   const classes = useStyles();
   const { photoURL, displayName, email } = user;
 
@@ -69,6 +77,17 @@ function UserProfileCard({ user, phoneNumber }) {
             </Box>
           )}
         </CardContent>
+        <CardActions disableSpacing>
+          <Button
+            fullWidth
+            variant="contained"
+            size="large"
+            classes={{ root: classes.lightButtonRoot, label: classes.lightButtonLabel }}
+            onClick={onButtonClick}
+          >
+            {editMode ? 'SAVE PROFILE UPDATES' : 'EDIT MY PROFILE'}
+          </Button>
+        </CardActions>
       </Card>
     </>
   );
@@ -77,6 +96,8 @@ function UserProfileCard({ user, phoneNumber }) {
 UserProfileCard.propTypes = {
   user: PropTypes.instanceOf(UserClass).isRequired,
   phoneNumber: PropTypes.string,
+  onButtonClick: PropTypes.func.isRequired,
+  editMode: PropTypes.bool.isRequired,
 };
 
 UserProfileCard.defaultProps = {


### PR DESCRIPTION
[Trello #231](https://trello.com/c/kBfqX2A0/231-as-a-user-i-want-to-be-able-to-enter-an-edit-mode-for-my-profile)
[Trello #232
](https://trello.com/c/C6EixkZd/232-as-a-user-i-want-to-be-able-to-edit-my-career-goal)
[Live env](https://nj-career-network-dev4.firebaseapp.com/profile/)

- Add CTA in left-rail profile card to switch between Edit Mode and View-only Mode
- Hide the Goal Header and show a text field for editing Goal under Edit Mode
- Can update goal in the storage when the user hits 'save'
- Can see CTA for add and edit experience under Edit Mode
