### PR TITLE
Bugfix: Partially Empty Employment

### DIFF
--- a/components/profile/EditDialog/EditDialog.js
+++ b/components/profile/EditDialog/EditDialog.js
@@ -54,7 +54,7 @@ function EditDialog({ show, onClose, mode, name, items, itemIndex }) {
     // If dialog is open and values have not been initialized
     if (show && !values && mode === UPDATE) {
       if (name === DIALOGS.EDIT_EMPLOYMENT) {
-        const { start, end, title, org } = items[itemIndex];
+        const { start = '', end = '', title = '', org = '' } = items[itemIndex];
         const [startMonth, startYear] = start.split(' ');
         const [endMonth, endYear] = end.split(' ');
         setValues({


### PR DESCRIPTION
Bug for editing employment when start/end date left empty (but rest filled out) introduced by https://github.com/newjersey/career-network/pull/173