### PR TITLE
Allow pulling support services questions by Label if Slug doesn't exist

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -46,15 +46,17 @@ function ProfilePage() {
       educationItems: isEmpty(educationItemsValue) ? [] : [educationItemsValue],
       employmentItems: isEmpty(employmentItemsValue) ? [] : [employmentItemsValue],
       supportServices: [
-        'unemployment-insurance',
-        'health-insurance',
-        'housing-assistance',
-        'food-assistance',
-        'energy-assistance',
-        'transportation',
-        'child-care',
-        'budgeting',
-      ].map(slug => getQuestionResponseDetails(allQuestionResponses, slug)),
+        { slug: 'unemployment-insurance', label: 'Unemployment Insurance' },
+        { slug: 'health-insurance', label: 'Health Insurance' },
+        { slug: 'housing-assistance', label: 'Housing Assistance' },
+        { slug: 'food-assistance', label: 'Food Assistance' },
+        { slug: 'energy-assistance', label: 'Energy Assistance' },
+        { slug: 'transportation', label: 'Transportation' },
+        { slug: 'child-care', label: 'Child & Family Care' },
+        { slug: 'budgeting', label: 'Budgeting' },
+      ]
+        .map(item => getQuestionResponseDetails(allQuestionResponses, item))
+        .filter(item => item !== null),
     };
   };
 

--- a/src/app-helper.js
+++ b/src/app-helper.js
@@ -124,15 +124,18 @@ export function getQuestionResponse(allQuestionResponses, slug) {
  * @returns {*} The response value as entered by the user.
  * @example getQuestionResponse(allQuestionResponses, 'most-recent-title')
  */
-export function getQuestionResponseDetails(allQuestionResponses, slug) {
-  const response = allQuestionResponses.find(qr => qr.data().question.fields.Slug === slug);
+export function getQuestionResponseDetails(allQuestionResponses, item) {
+  const response = allQuestionResponses.find(
+    qr =>
+      qr.data().question.fields.Slug === item.slug || qr.data().question.fields.Label === item.label
+  );
 
   if (!response) {
     return null;
   }
 
   return {
-    slug,
+    slug: item.slug,
     label: response.data().question.fields.Label,
     value: response.data().value,
     helperText: response.data().question.fields['Helper Text'],


### PR DESCRIPTION
To accommodate the existing assessment data, which doesn't have the slug field.