### PR TITLE
Add active applications count to tout on dashboard

### DIFF
--- a/components/dashboard/ApplicationTrackerCard.js
+++ b/components/dashboard/ApplicationTrackerCard.js
@@ -7,6 +7,8 @@ import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import NextLink from 'next/link';
 
+import FirebasePropTypes from '../Firebase/PropTypes';
+
 const useStyles = makeStyles(theme => ({
   card: {
     padding: theme.spacing(2),
@@ -25,9 +27,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ApplicationTrackerCard() {
+function ApplicationTrackerCard({ applications }) {
   const classes = useStyles();
-  const activeApplicationsCount = 0;
+  const activeApplications = applications.filter(item => item && item.data().isActive);
+  const activeApplicationsCount = activeApplications.length;
 
   return (
     <>
@@ -58,6 +61,8 @@ function ApplicationTrackerCard() {
   );
 }
 
-ApplicationTrackerCard.propTypes = {};
+ApplicationTrackerCard.propTypes = {
+  applications: FirebasePropTypes.querySnapshot.isRequired,
+};
 
 export default ApplicationTrackerCard;

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -272,6 +272,7 @@ export default function Dashboard(props) {
     completedTasks,
     historyLimit,
     allActivityLogEntries,
+    allApplicationLogEntries,
     ...restProps
   } = props;
 
@@ -281,7 +282,6 @@ export default function Dashboard(props) {
     user.lastSentimentTimestamp && isToday(user.lastSentimentTimestamp.toDate());
   const isSentimentClosedToday =
     user.lastSentimentCloseTimestamp && isToday(user.lastSentimentCloseTimestamp.toDate());
-
   const showSentiment = !isSentimentLoggedToday || !isSentimentClosedToday;
 
   const onRecordSentiment = sentiment => {
@@ -433,7 +433,7 @@ export default function Dashboard(props) {
             </Card>
             <Flags authorizedFlags={['applicationTracker']}>
               <Box mt={3}>
-                <ApplicationTrackerCard />
+                <ApplicationTrackerCard applications={allApplicationLogEntries} />
               </Box>
             </Flags>
             <Box mt={3} data-intercom="log-interview">
@@ -478,6 +478,7 @@ Dashboard.propTypes = {
   completedTasks: FirebasePropTypes.querySnapshot,
   historyLimit: PropTypes.number.isRequired,
   allActivityLogEntries: FirebasePropTypes.querySnapshot,
+  allApplicationLogEntries: FirebasePropTypes.querySnapshot,
   interviewLogEntries: FirebasePropTypes.querySnapshot,
 };
 
@@ -486,5 +487,6 @@ Dashboard.defaultProps = {
   allTaskDispositionEvents: [],
   completedTasks: [],
   allActivityLogEntries: [],
+  allApplicationLogEntries: [],
   interviewLogEntries: [],
 };

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -27,6 +27,10 @@ function DashboardPage() {
     orderBy: ['timestamp', 'desc'],
   });
 
+  const allApplicationLogEntries = useUserSubcollection('applicationLogEntries', {
+    orderBy: ['lastUpdateTimestamp', 'desc'],
+  });
+
   const recordProps = {
     allPredicates: useRecords('Predicates'),
     allConditions: useRecords('Conditions'),
@@ -41,6 +45,7 @@ function DashboardPage() {
     allQuestionResponses,
     allActionDispositionEvents,
     allActivityLogEntries,
+    allApplicationLogEntries,
     completedTasks
   ) ? (
     <Dashboard
@@ -48,6 +53,7 @@ function DashboardPage() {
       allActionDispositionEvents={allActionDispositionEvents}
       allTaskDispositionEvents={allTaskDispositionEvents}
       allActivityLogEntries={allActivityLogEntries}
+      allApplicationLogEntries={allApplicationLogEntries}
       completedTasks={completedTasks}
       historyLimit={HISTORY_LIMIT}
       interviewLogEntries={interviewLogEntries}


### PR DESCRIPTION
[Live env](https://nj-career-network-dev4.firebaseapp.com/)

Add functionality to display the active applications count in the application-tracker card in dashboard

<img width="328" alt="Screen Shot 2020-05-21 at 1 54 18 PM" src="https://user-images.githubusercontent.com/40243087/82589751-995bf280-9b6a-11ea-9fba-6e088ef604b9.png">
