### PR TITLE
Bugfix: Product Tour

### DIFF
--- a/components/AppManager.js
+++ b/components/AppManager.js
@@ -104,8 +104,6 @@ export default function AppManager(props) {
     // the timeout prevents some kind of race condition that throws a benign console
     // error when booting immediately after the above "clean slate" shutdown
     window.setTimeout(() => window.Intercom('boot', config), 1);
-
-    return () => window.Intercom('shutdown');
   }, [
     intercomUserHash,
     userCreationTimestampSeconds,


### PR DESCRIPTION
[Trello](https://trello.com/c/04QFq0PK/267-bug-fix-product-tour-not-showing-up-on-user-dashboard)
[Live Env](https://preview.njcareers.org/dashboard/?product_tour_id=126256)

The user sees a product tour popup when they visit the product tour url while logged in
Once logged out, the user does not see any of the intercom messages they sent while logged in