### PR TITLE
Display career goal in dashboard user profile card

### DIFF
--- a/components/dashboard/UserProfileCard.js
+++ b/components/dashboard/UserProfileCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import Avatar from '@material-ui/core/Avatar';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
@@ -57,6 +58,16 @@ function UserProfileCard({ user }) {
             </Grid>
           </Grid>
           <Divider variant="fullWidth" />
+          {user.userData && user.userData.userProfile && user.userData.userProfile.goal && (
+            <Box mt={2}>
+              <Typography variant="body2" component="h3" gutterBottom>
+                <b>CAREER GOAL</b>
+              </Typography>
+              <Typography variant="body2" component="p">
+                {user.userData.userProfile.goal}
+              </Typography>
+            </Box>
+          )}
         </CardContent>
         <CardActions disableSpacing>
           <NextLink href="/profile">


### PR DESCRIPTION
[Trello card](https://trello.com/c/1AJ5igmQ/275-bug-display-jobseekers-goal-in-the-profile-card-on-the-dashboard)
<img width="407" alt="Screen Shot 2020-06-01 at 4 05 42 PM" src="https://user-images.githubusercontent.com/40243087/83449523-c7bab700-a421-11ea-887d-0b4c0caf94c4.png">
