### PR TITLE
Feature: Add LinkedIn single sign-on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ See for identity verification secret info: https://www.intercom.com/help/en/arti
 
 (Optional) Preview the exported static site locally:
 
+The LinkedIn Auth uses the default service accounts for [signing custom tokens](https://firebase.google.com/docs/auth/admin/create-custom-tokens), if that account don't have the `iam.serviceAccounts.signBlob` permission, you may use [IAM and admin](https://console.cloud.google.com/projectselector2/iam-admin) of the Google Cloud Platform Console to grant it with the necessary permissions.
+
 ```sh
 npm run preview
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Enter your Intercom test identity verification secret into `functions/.runtimeco
 
 See for identity verification secret info: https://www.intercom.com/help/en/articles/183-enable-identity-verification-for-web-and-mobile
 
-Download the service account private key (Firebase console --> Settings --> Service accounts), and put it under root directory of /functions with name 'service-account.json'
+Enter LinkedIn App ID and secret into `functions/.runtimeconfig.json`
 
 ## Testing
 

--- a/components/Auth/AuthForm.js
+++ b/components/Auth/AuthForm.js
@@ -2,9 +2,9 @@ import { makeStyles } from '@material-ui/styles';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth';
-// import Box from '@material-ui/core/Box';
-// import Button from '@material-ui/core/Button';
-// import LinkedInIcon from '@material-ui/icons/LinkedIn';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+import LinkedInIcon from '@material-ui/icons/LinkedIn';
 
 import { useFirebase } from '../Firebase';
 import FullPageProgress from '../FullPageProgress';
@@ -35,7 +35,7 @@ export default function AuthForm(props) {
   const { auth } = useFirebase();
   const classes = useStyles();
   const [uiShown, setUiShown] = useState(false);
-  // const linkedinUrl = `https://us-central1-${process.env.firebase.projectId}.cloudfunctions.net/linkedinRedirect`;
+  const linkedinUrl = `https://us-central1-${process.env.firebase.projectId}.cloudfunctions.net/linkedinRedirect`;
   const uiConfig = {
     callbacks: {
       signInSuccessWithAuthResult(authResult, redirectUrl) {
@@ -82,20 +82,20 @@ export default function AuthForm(props) {
     privacyPolicyUrl: '/privacy-policy',
   };
 
-  // const handleClick = () => {
-  //   window.open(linkedinUrl, '', 'width=500, height=700, left=600');
-  // };
+  const handleClick = () => {
+    window.open(linkedinUrl, '', 'width=500, height=700, left=600');
+  };
 
   return (
     <div className={classes.root}>
-      {/* <Box display="flex" justifyContent="center">
+      <Box display="flex" justifyContent="center">
         <Box boxShadow={2}>
           <Button className={classes.button} size="large" onClick={handleClick}>
             <LinkedInIcon style={{ marginRight: '0.5em', marginLeft: '-0.7em' }} />
             Sign in with LinkedIn
           </Button>
         </Box>
-      </Box> */}
+      </Box>
       <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={auth()} />
       {!uiShown && (
         <div className={classes.progressContainer}>

--- a/functions/.runtimeconfig.json-example
+++ b/functions/.runtimeconfig.json-example
@@ -9,7 +9,7 @@
     "api_key": "YOUR SECRET ACCOUNT API KEY"
   },
   "linkedin": {
-    "client_id": "CLIENT_ID",
-    "client_secret": "CLIENT_SECRET"
+    "client_id": "LINKEDIN APP CLIENT_ID",
+    "client_secret": "LINKEDIN APP CLIENT_SECRET"
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,20 +6,9 @@ const functions = require('firebase-functions');
 const https = require('https');
 
 const { WebClient: SlackWebClient } = require('@slack/web-api');
-// const { linkedinRedirect, linkedinAuthorize } = require('./linkedinAuth');
+const { linkedinRedirect, linkedinAuthorize } = require('./linkedinAuth');
 
 admin.initializeApp();
-
-// TODO: Swith to using service account ID (with right permission)
-// instead of the JSON private key
-// admin.initializeApp({
-//   credential: admin.credential.cert(
-//     // Generate from Firebase console --> Settings --> Service accounts
-//     // eslint-disable-next-line global-require, import/no-unresolved, import/no-extraneous-dependencies
-//     require('./service-account.json')
-//   ),
-//   databaseURL: `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
-// });
 
 const postSlackMessage = async (conversationId, text, options = {}) => {
   const config = functions.config().slack;
@@ -174,5 +163,5 @@ exports.intercomUserHash = functions.auth.user().onCreate(user => {
     .set({ intercomUserHash: hash }, { merge: true });
 });
 
-// exports.linkedinRedirect = linkedinRedirect;
-// exports.linkedinAuthorize = linkedinAuthorize;
+exports.linkedinRedirect = linkedinRedirect;
+exports.linkedinAuthorize = linkedinAuthorize;

--- a/functions/linkedinAuth.js
+++ b/functions/linkedinAuth.js
@@ -10,6 +10,19 @@ const cors = require('cors')({ origin: true });
 const admin = require('firebase-admin');
 
 const OAUTH_SCOPES = ['r_liteprofile', 'r_emailaddress'];
+const PREVIEW_PROJECT_ID = 'nj-career-network';
+const PROD_PROJECT_ID = 'nj-career-network';
+
+const getCallBackUrl = projectId => {
+  switch (projectId) {
+    case PREVIEW_PROJECT_ID:
+      return `https://preview.njcareers.org/popup`;
+    case PROD_PROJECT_ID:
+      return `https://njcareers.org/popup`;
+    default:
+      return `https://${projectId}.firebaseapp.com/popup`;
+  }
+};
 
 /**
  * Creates a configured LinkedIn API Client instance.
@@ -23,10 +36,13 @@ function linkedInClient() {
     return null;
   }
 
+  const projectId = process.env.GCLOUD_PROJECT;
+  const callbackUrl = getCallBackUrl(projectId);
+
   return nodeLinkedinClient(
     functions.config().linkedin.client_id,
     functions.config().linkedin.client_secret,
-    `https://preview.njcareers.org/popup`
+    callbackUrl
   );
 }
 

--- a/functions/linkedinAuth.js
+++ b/functions/linkedinAuth.js
@@ -10,7 +10,7 @@ const cors = require('cors')({ origin: true });
 const admin = require('firebase-admin');
 
 const OAUTH_SCOPES = ['r_liteprofile', 'r_emailaddress'];
-const PREVIEW_PROJECT_ID = 'nj-career-network';
+const PREVIEW_PROJECT_ID = 'nj-career-network-ppe';
 const PROD_PROJECT_ID = 'nj-career-network';
 
 const getCallBackUrl = projectId => {


### PR DESCRIPTION
[Live env](https://nj-career-network-dev2.firebaseapp.com)
[Trello card](https://trello.com/c/KMts1No6/3-request-linkedin-single-sign-on)

- Remove the usage of Service Account JSON, so we will use App Engine default service account to create custom tokens. And GRANT`iam.serviceAccounts.signBlob` permission by adding role `Service Account Token Creator` to the default service account.
https://firebase.google.com/docs/auth/admin/create-custom-tokens

- Set the callback URL according to stage
- Add back the UI for linkedin login