### PR TITLE
[Draft] Activity Page Skeleton

### DIFF
--- a/data/activity-pages.json
+++ b/data/activity-pages.json
@@ -1,4 +1,5 @@
 {
+  "slug": "activity-template-0",
   "category": "<JOB_SEARCH_BASICS_CATEGORY>",
   "milestone": "<MILESTONE_TYPE>",
   "title": "title string",
@@ -54,8 +55,9 @@
           "content": "helloooo"
         },
         {
-          "component": "activity_inputs"
-        
+          "component": "practice_question",
+          "questionId": "q-uuid",
+          "order": 0
         }
       ]
     },
@@ -66,3 +68,11 @@
     }
   ]
 }
+
+// specify document id for template uuid
+// store activity template inputs in user/activityTemplateEntries/<template uuid>/<question input values>
+
+// Unique id for every Practice question
+// Unique id used to persist responses
+// Are the questions fixed for the template?
+// how are they currently managing activities that they author?

--- a/data/activity-pages.json
+++ b/data/activity-pages.json
@@ -1,0 +1,68 @@
+{
+  "category": "<JOB_SEARCH_BASICS_CATEGORY>",
+  "milestone": "<MILESTONE_TYPE>",
+  "title": "title string",
+  "total_time": 15,
+  "sections": [
+    {
+      "name": "What & Why",
+      "slug": "what-and-why",
+      "content": [
+        {
+        "component": "text",
+        "content": "lowerasdfasljlk"
+      }
+    ]
+    },
+    {
+      "name": "Tips for Success",
+      "slug": "tips-for-success",
+      "content": [{
+          "component": "list",
+          "content": [
+            "one",
+            "two",
+            "three"
+          ]
+        },
+        {
+          "component": "callout",
+          "type": "pro-tip",
+          "content": "asfasdfasdf"
+        }
+      ]
+    },
+    {
+      "name": "Examples",
+      "slug": "examples",
+      "content": [{
+          "component": "text",
+          "content": "helloooo"
+        },
+        {
+          "component": "callout",
+          "type": "quote",
+          "content": "asfasdfasdf"
+        }
+      ]
+    },
+    {
+      "name": "Practice",
+      "slug": "practice",
+      "content": [{
+          "component": "text",
+          "content": "helloooo"
+        },
+        {
+          "component": "activity_inputs"
+        
+        }
+      ]
+    },
+    {
+      "name": "Next Steps",
+      "slug": "next-steps",
+      "content": "lowerasdfasljlk"
+    }
+  ]
+}

--- a/data/job-search-categories.json
+++ b/data/job-search-categories.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Finding Job Opportunities",
+    "slug": "finding-job-opportunities"
+  },
+  {
+    "name": "Applying for Jobs",
+    "slug": "applying-for-jobs"
+  },
+  {
+    "name": "Taking Care of Yourself",
+    "slug": "health"
+  }
+]

--- a/data/milestone-types.json
+++ b/data/milestone-types.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Resume",
+    "category_slug": "applying-for-jobs",
+    "slug": "resume"
+  },
+  {
+    "name": "Personal Values",
+    "category_slug": "health",
+    "slug": "personal-values"
+  },
+  {
+    "name": "Interviewing Skills",
+    "category_slug": "applying-for-jobs",
+    "slug": "interviewing-skills"
+  }
+]


### PR DESCRIPTION
NOTES:

- specify document id for template uuid
- store activity template inputs in user/activityTemplateEntries/<template uuid>/<question input values>

- Unique id for every Practice question
- Unique id used to persist responses
- Are the questions fixed for the template?
- how are they currently managing activities that they author?
