### PR TITLE
Update/Header : Remove About Page

### DIFF
--- a/components/header/Nav.js
+++ b/components/header/Nav.js
@@ -173,7 +173,7 @@ function Nav(props) {
       href: '/about',
       name: 'About',
       shortName: 'About',
-      show: true,
+      show: false,
     },
     {
       href: '',

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { makeStyles } from '@material-ui/styles';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
@@ -6,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Picture from '../components/Picture';
 import ScaffoldContainer from '../components/ScaffoldContainer';
 import withTitle from '../components/withTitle';
+import Error from './_error';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -168,4 +170,4 @@ function About() {
   );
 }
 
-export default withTitle(About, 'About');
+export default withTitle(Error, 'About');


### PR DESCRIPTION
[Live Env](https://nj-career-network-dev2.firebaseapp.com/)
[Trello](https://trello.com/c/UnmhPr04/323-remove-about-from-the-global-nav)

- Hid "About" from view on Nav
- https://njcareers.org/about leads to Unexpected Error page