### PR TITLE
Update: Display 3 activities at a time on dashboard

### DIFF
--- a/activity-templates/templates/activity-template-33.json
+++ b/activity-templates/templates/activity-template-33.json
@@ -6,7 +6,7 @@
   "category": "health",
   "milestone": "strenths-and-values",
   "total_time": "30 min",
-  "activitySequence": 2,
+  "activitySequence": 3,
   "sections": [
     {
       "name": "What & Why",

--- a/activity-templates/templates/activity-template-34.json
+++ b/activity-templates/templates/activity-template-34.json
@@ -6,7 +6,7 @@
   "category": "health",
   "milestone": "strenths-and-values",
   "total_time": "15 min",
-  "activitySequence": 3,
+  "activitySequence": 2,
   "sections": [
     {
       "name": "What & Why",

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -38,6 +38,7 @@ import CelebrationDialog from '../CelebrationDialog';
 import ActivityTemplateCard from './ActivityTemplateCard';
 
 const TASK_COUNT_LIMIT = 3;
+const ACTIVITY_DISPLAY = 3;
 const ROW_GAP = 2;
 const COL_GAP = 2;
 
@@ -493,7 +494,7 @@ export default function Dashboard(props) {
               authorizedFlags={['activityTemplate']}
               renderOn={() =>
                 incompleteActivityTemplates
-                  .slice(0, 3)
+                  .slice(0, ACTIVITY_DISPLAY)
                   .map(template => (
                     <ActivityTemplateCard
                       key={template.slug}

--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -492,13 +492,15 @@ export default function Dashboard(props) {
             <Flags
               authorizedFlags={['activityTemplate']}
               renderOn={() =>
-                incompleteActivityTemplates.map(template => (
-                  <ActivityTemplateCard
-                    key={template.slug}
-                    totalTime={template.total_time}
-                    {...template}
-                  />
-                ))
+                incompleteActivityTemplates
+                  .slice(0, 3)
+                  .map(template => (
+                    <ActivityTemplateCard
+                      key={template.slug}
+                      totalTime={template.total_time}
+                      {...template}
+                    />
+                  ))
               }
               renderOff={() => (
                 <TaskList


### PR DESCRIPTION
[Trello](https://trello.com/c/kh9AulmU/327-dashboard-logic-display-3-activities-at-a-time)
[Live env](https://nj-career-network-dev2.firebaseapp.com/dashboard/)

- Add `slice()` function to incompleteActivityTemplate mapping.
- Made sure no duplicate activity bug appeared.
- New tasks would appear after one was completed until there was completely no activities left