### PR TITLE
Feature: Add view button and routing to completed activity for Action Log items

### DIFF
--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -533,7 +533,7 @@ export default function Dashboard(props) {
                   <CardHeader
                     title={
                       <Typography component="h2" variant="h6" data-intercom="activity-title">
-                        Action Log
+                        Recent Actions
                       </Typography>
                     }
                     disableTypography

--- a/components/dashboard/ProgressFeed.js
+++ b/components/dashboard/ProgressFeed.js
@@ -101,7 +101,7 @@ export default function ProgressFeed(props) {
               data-intercom="all-progress-button"
               fullWidth
             >
-              View All Activities
+              View All Actions
             </Button>
           </NextLink>
         </Box>

--- a/components/history/ActionItem.js
+++ b/components/history/ActionItem.js
@@ -27,6 +27,11 @@ const useStyles = makeStyles(theme => ({
   },
   description: {
     marginTop: theme.spacing(2),
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    display: '-webkit-box',
+    '-webkit-line-clamp': 2,
+    '-webkit-box-orient': 'vertical',
   },
   openButton: {
     backgroundColor: theme.palette.grey['100'],

--- a/components/history/ActionItem.js
+++ b/components/history/ActionItem.js
@@ -6,6 +6,7 @@ import Card from '@material-ui/core/Card';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
+import NextLink from 'next/link';
 import { format } from 'date-fns';
 
 import ActionIcon from '../dashboard/ActionPlan/ActionIcon';
@@ -36,7 +37,7 @@ const useStyles = makeStyles(theme => ({
 
 function ActionItem(props) {
   const classes = useStyles();
-  const { title, why, dateCompleted, actionType, openDetails } = props;
+  const { title, why, dateCompleted, actionType, openDetails, activityTemplateId } = props;
 
   return (
     <>
@@ -66,6 +67,13 @@ function ActionItem(props) {
               Open
             </Button>
           )}
+          {activityTemplateId && (
+            <NextLink href={`/activity-template?template=${activityTemplateId}`}>
+              <Button className={classes.openButton} variant="contained">
+                View
+              </Button>
+            </NextLink>
+          )}
         </div>
         {why && (
           <Typography
@@ -92,11 +100,13 @@ ActionItem.propTypes = {
     color: PropTypes.string.isRequired,
   }).isRequired,
   openDetails: PropTypes.func,
+  activityTemplateId: PropTypes.string,
 };
 
 ActionItem.defaultProps = {
   why: null,
   openDetails: null,
+  activityTemplateId: null,
 };
 
 export default ActionItem;

--- a/components/history/History.js
+++ b/components/history/History.js
@@ -70,6 +70,10 @@ const getActivityCategoryName = activityTypeValue => {
   return matchingActivity ? matchingActivity.category.name : unrecognizedCategoryName;
 };
 
+const getActivityTemplateId = taskId => {
+  return taskId.startsWith('activity-template') ? taskId : null;
+};
+
 const DIALOGS = {
   ACTIVITY_INPUT: 'ActivityInputDialog',
   ACTIVITY_DETAIL: 'ActivityDetailDialog',
@@ -133,6 +137,7 @@ export default function History(props) {
         dateCompleted: timestamp,
         id: taskEvent.id,
         actionType: ACTION_TYPES.goal,
+        activityTemplateId: getActivityTemplateId(task.id),
       },
     };
   });


### PR DESCRIPTION
[Live env](https://nj-career-network-dev4.firebaseapp.com/progress)
[Trello card](https://trello.com/c/mwJXmGeK/350-route-from-action-log-back-to-a-completed-activity)

- Add view button and routing to completed activity
- Make sure it won't break by deprecated task data
- Display Truncated Activity Description - 2 Lines then an Ellipsis
