### PR TITLE
Update : add dashboard return button to JBS page

### DIFF
--- a/components/activityTemplate/Section.js
+++ b/components/activityTemplate/Section.js
@@ -25,11 +25,16 @@ function Section({ sectionData, onComplete, scrollToRef, ...restProps }) {
   const classes = useStyles(restProps);
   const getSectionKey = (type, index) => `${type}-${index}`;
   const nextStep = sectionData.slug === 'next-steps';
+  const dashboardReturn = sectionData.slug === 'dashboard-return';
 
   return (
     <div className={classes.root} ref={scrollToRef}>
       <ScaffoldContainer>
-        <Grid container justify={nextStep ? 'flex-start' : 'flex-end'} spacing={4}>
+        <Grid
+          container
+          justify={nextStep || dashboardReturn ? 'flex-start' : 'flex-end'}
+          spacing={4}
+        >
           <Grid item container xs={12} sm={2}>
             <Typography variant="h2" align="right">
               {sectionData.name}
@@ -60,6 +65,20 @@ function Section({ sectionData, onComplete, scrollToRef, ...restProps }) {
                 onClick={onComplete}
               >
                 COMPLETE THIS ACTIVITY
+              </Button>
+            </NextLink>
+          )}
+
+          {dashboardReturn && (
+            <NextLink href="/dashboard">
+              <Button
+                classes={{ root: classes.button }}
+                fullWidth
+                variant="contained"
+                size="large"
+                color="primary"
+              >
+                RETURN TO MY DASHBOARD
               </Button>
             </NextLink>
           )}

--- a/components/activityTemplate/components/Callout.js
+++ b/components/activityTemplate/components/Callout.js
@@ -59,13 +59,20 @@ function Callout({ content, variant, description }) {
         return <FormatQuote />;
       case 'next':
         return <ForwardIcon />;
+      case 'dashboard':
+        return <InfoOutlined />;
       default:
         return null;
     }
   };
 
   return (
-    <div className={clsx(classes.root, variant === 'next' && classes.next)}>
+    <div
+      className={clsx(
+        classes.root,
+        (variant === 'next' || variant === 'dashboard') && classes.next
+      )}
+    >
       {description && (
         <Typography variant="h5" className={classes.description}>
           {description}
@@ -93,7 +100,7 @@ function Callout({ content, variant, description }) {
 
 Callout.propTypes = {
   content: PropTypes.string.isRequired,
-  variant: PropTypes.oneOf(['pro-tip', 'quote', 'next']).isRequired,
+  variant: PropTypes.oneOf(['pro-tip', 'quote', 'next', 'dashboard']).isRequired,
   description: PropTypes.string,
 };
 

--- a/components/jobSearchBasics/JobSearchBasics.js
+++ b/components/jobSearchBasics/JobSearchBasics.js
@@ -4,7 +4,11 @@ import Grid from '@material-ui/core/Grid';
 import React, { useState, useRef } from 'react';
 import Typography from '@material-ui/core/Typography';
 
+import { fullyLoaded } from '../../src/app-helper';
+import { useAuth } from '../Auth';
+
 import ScaffoldContainer from '../ScaffoldContainer';
+import Section from '../activityTemplate/Section';
 import FindingJob from './FindingJob';
 import ApplyForJob from './ApplyForJob';
 import Health from './Health';
@@ -48,12 +52,29 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const calloutData = [
+  {
+    slug: 'dashboard-return',
+    content: [
+      {
+        component: 'callout',
+        variant: 'dashboard',
+        content:
+          'Start with 1 of the 3 Recommended Activities, on your dashboard. Remember, you can come back to this page at anytime and access all the activities via the milestones above.',
+      },
+    ],
+  },
+];
+
 export default function JobSearchBasics() {
+  const { user } = useAuth();
   const classes = useStyles();
   const [shape, setShowShape] = useState(FINDING_JOB);
   const findingJobSection = useRef(null);
   const applyForJobSection = useRef(null);
   const healthSection = useRef(null);
+
+  const dashboardReturn = calloutData.find(sec => sec.slug === 'dashboard-return');
 
   const handleScrollTo = section => {
     const selectedSection = {
@@ -125,6 +146,7 @@ export default function JobSearchBasics() {
       <FindingJob scrollToRef={findingJobSection} />
       <ApplyForJob scrollToRef={applyForJobSection} />
       <Health scrollToRef={healthSection} />
+      {fullyLoaded(user) && <Section sectionData={dashboardReturn} />}
     </div>
   );
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/JODQaJku/354-direct-people-to-the-dashboard-from-the-jsb-page)
[Live Env](https://nj-career-network-dev2.firebaseapp.com/job-search-basics/)

- added Return to Dashboard button on bottom of JBS page
- updated Callout and Section components to support new Dashboard Button design (styling of 'next' variant, but has icon of 'pro-tip' variant)