### PR TITLE
Update activities display logic #346

### DIFF
--- a/components/dashboard/Dashboard.js
+++ b/components/dashboard/Dashboard.js
@@ -317,27 +317,33 @@ export default function Dashboard(props) {
   } = props;
 
   const tasks = getTasks(props, TASK_COUNT_LIMIT);
-  const completedActivities = completedTasks
-    .map(task => task.data())
-    .filter(taskData => taskData.taskId.startsWith('activity-template'))
-    .sort((a, b) => compareDesc(a.timestamp, b.timestamp));
 
-  const incompleteActivities = allActivityTemplates
-    .filter(
-      template => !completedActivities.map(activity => activity.taskId).includes(template.slug)
-    )
-    .sort((a, b) => a.priority - b.priority);
-
-  const nextHealthActivity = incompleteActivities.find(template => template.category === 'health');
   const nextActivities = useMemo(() => {
-    const nonHealth = incompleteActivities.filter(template => template.category !== 'health');
+    const completedActivities = completedTasks
+      .map(task => task.data())
+      .filter(taskData => taskData.taskId.startsWith('activity-template'))
+      .sort((a, b) => compareDesc(a.timestamp, b.timestamp));
+
+    const incompleteActivities = allActivityTemplates
+      .filter(
+        template => !completedActivities.map(activity => activity.taskId).includes(template.slug)
+      )
+      .sort((a, b) => a.priority - b.priority);
+
+    const nextHealthActivity = incompleteActivities.find(
+      template => template.category === 'health'
+    );
+    const nonHealthActivities = incompleteActivities.filter(
+      template => template.category !== 'health'
+    );
+
     if (nextHealthActivity) {
-      const display = nonHealth.slice(0, ACTIVITY_DISPLAY - 1);
+      const display = nonHealthActivities.slice(0, ACTIVITY_DISPLAY - 1);
       display.push(nextHealthActivity);
       return display;
     }
-    return nonHealth.slice(0, ACTIVITY_DISPLAY);
-  }, [incompleteActivities, nextHealthActivity]);
+    return nonHealthActivities.slice(0, ACTIVITY_DISPLAY);
+  }, [allActivityTemplates, completedTasks]);
 
   const [activeDialog, setActiveDialog] = useState();
   const isSentimentLoggedToday =


### PR DESCRIPTION
[Trello card](https://trello.com/c/2YIEH9Vi/346-dashboard-display-activities-in-a-universal-sequence)
[Live env](https://nj-career-network-dev4.firebaseapp.com/dashboard)

- One ‘taking care’ activity always shows at the bottom of the current display, before it runs out.

- Displayed activities will come from two queues, one for non ‘taking care’ and one for ‘taking care’, all ordered by our defined priority