### PR TITLE
Update Action Plan Setting Inputs Autofocus 

### DIFF
--- a/components/dashboard/ActionPlan/ActionPlanUpdateDialog.js
+++ b/components/dashboard/ActionPlan/ActionPlanUpdateDialog.js
@@ -148,7 +148,6 @@ function ActionPlanUpdateDialog(props) {
             </Grid>
             <Grid item xs={12} sm={3}>
               <TextField
-                autoFocus
                 className={classes.input}
                 id={`${formId}-activities`}
                 inputProps={{ name: 'activities', min: 0 }}
@@ -173,7 +172,6 @@ function ActionPlanUpdateDialog(props) {
             </Grid>
             <Grid item xs={12} sm={3}>
               <TextField
-                autoFocus
                 className={classes.input}
                 id={`${formId}-applications`}
                 inputProps={{ name: 'applications', min: 0 }}


### PR DESCRIPTION
Change the autofocus to be on the first input.

Request from [Trello ](https://trello.com/c/ZpdrN2X7/358-mobile-bug-hunt-refactor-the-update-action-plan-modal)