### PR TITLE
Turn on feature flag for new landing page and job search basics features

### DIFF
--- a/src/feature-flags.js
+++ b/src/feature-flags.js
@@ -22,19 +22,19 @@ const envConfigs = {
     },
     {
       name: 'jobSearchBasics',
-      isActive: false,
+      isActive: true,
     },
     {
       name: 'activityTemplate',
-      isActive: false,
+      isActive: true,
     },
     {
       name: 'landingPage',
-      isActive: false,
+      isActive: true,
     },
     {
       name: 'milestonePages',
-      isActive: false,
+      isActive: true,
     },
     {
       name: 'upcomingInterview',


### PR DESCRIPTION
Turn on all the feature flag related to new landing page and job search basics

[trello 321](https://trello.com/c/ERc7nKtf/321-enable-the-feature-flag-for-njcn-landing-page)
[trello 284](https://trello.com/c/8lTjsz82/284-enable-feature-flag-for-job-search-basics-in-production)


