### PR TITLE
Adjust required fields

### DIFF
--- a/components/assessment/Question/Question.js
+++ b/components/assessment/Question/Question.js
@@ -162,14 +162,14 @@ function Question(props) {
     ...commonQuestionProps,
     onBlur: _value => setValue(_value),
     onChange: _value => setLocalValue(_value),
-    value: localValue,
+    value: localValue || '',
   };
 
   const monthYearQuestionProps = {
     ...commonQuestionProps,
     isCurrentJobSelected, // if question with slug is-current-job is selected
     views: dateInputOptions,
-    optional: isLastInGroup ? isCurrentJobSelected && optional : !isCurrentJobSelected, //  end is optional but must select start if isCurrentJob is true
+    optional: isLastInGroup && isCurrentJobSelected ? true : optional, //  if isCurrentJob then end date is always optional
     groupIsValid,
     isLastInGroup,
     onChange: _value => setLocalValue(_value),

--- a/components/assessment/RangeQuestionGroup.js
+++ b/components/assessment/RangeQuestionGroup.js
@@ -60,7 +60,9 @@ export default function RangeQuestionGroup(props) {
     // determine if the QuestionGroup as a whole is valid
     const isValid =
       validationStates.current.map(a => !!a).reduce((a, b) => a && b, true) &&
-      (isCurrentJobQuestion || isValidRange(valueStates.current[0], valueStates.current[1]));
+      (restProps.optional ||
+        isCurrentJobQuestion ||
+        isValidRange(valueStates.current[0], valueStates.current[1]));
 
     // fire parent callback if validation has changed
     if (wasValid.current !== isValid) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11681,25 +11681,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "requires": {
@@ -11709,13 +11709,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -11731,25 +11731,25 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
@@ -11764,19 +11764,19 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true
         },
@@ -11791,13 +11791,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
@@ -11827,7 +11827,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
@@ -11851,7 +11851,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -11867,13 +11867,13 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -11882,13 +11882,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -11937,7 +11937,7 @@
         },
         "needle": {
           "version": "2.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "dev": true,
           "requires": {
@@ -11966,7 +11966,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
@@ -11976,7 +11976,7 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true
         },
@@ -11992,7 +11992,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
@@ -12004,19 +12004,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -12025,19 +12025,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
@@ -12047,13 +12047,13 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "dev": true
         },
@@ -12071,7 +12071,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
@@ -12083,7 +12083,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -12107,19 +12107,19 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true
         },
@@ -12131,7 +12131,7 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
@@ -12143,7 +12143,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -12154,7 +12154,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -12163,7 +12163,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12172,7 +12172,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
@@ -12193,13 +12193,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "requires": {
@@ -12208,7 +12208,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },

--- a/public/static/api/Assessment Entries
+++ b/public/static/api/Assessment Entries
@@ -169,6 +169,7 @@
           "reciquqWJom8D43QI"
         ],
         "Order": 1,
+        "Optional": true,
         "Assessment Subsection": [
           "reciuMFImzTFxi6nI"
         ],
@@ -303,6 +304,7 @@
           "recyOfqkNspqhLYEc"
         ],
         "Order": 1,
+        "Optional": true,
         "Assessment Subsection": [
           "recWJEzKO3jeZhGdJ"
         ],
@@ -329,6 +331,7 @@
           "rec89z2RcqJvMXEV4"
         ],
         "Order": 2,
+        "Optional": true,
         "Assessment Subsection": [
           "recWJEzKO3jeZhGdJ"
         ],
@@ -355,6 +358,7 @@
           "recNNm1JNICZ2mhje"
         ],
         "Order": 3,
+        "Optional": true,
         "Assessment Subsection": [
           "recWJEzKO3jeZhGdJ"
         ],

--- a/public/static/api/Assessment Entries
+++ b/public/static/api/Assessment Entries
@@ -1,1 +1,576 @@
-{"records":[{"id":"recYONnfuLAEV6ONS","fields":{"Internal Notes":"Currently auto-populated","Question":["recwKxBPzV84ZWIJ5"],"Order":1,"Assessment Subsection":["recLuL0rh0ZPN0Rb8"],"Subsection:Number":["1.1"],"Entry Text":"Full name","Assessment Section":["recW5wjaveWt8ej9X"],"Question:Label":["Full name"],"Name":"Full name","Question Count":1,"Number":"1.1.1"},"createdTime":"2020-03-06T06:52:12.000Z"},{"id":"recEcw1JVST0tzU7J","fields":{"Internal Notes":"Auto-populated and used so that we can key predicates off the user's email address.\n\nIn the future, maybe make this disabled if using SSO but enabled if using text auth?","Question":["recbIKyicFBLz3mbI"],"Order":2,"Assessment Subsection":["recLuL0rh0ZPN0Rb8"],"Subsection:Number":["1.1"],"Entry Text":"Email","Assessment Section":["recW5wjaveWt8ej9X"],"Question:Label":["Email address"],"Name":"Email address","Question Count":1,"Number":"1.1.2"},"createdTime":"2019-06-28T04:08:04.000Z"},{"id":"recnByH6HIktAHCtR","fields":{"Question":["recDkvWeqvMxahFT2"],"Order":3,"Optional":true,"Assessment Subsection":["recLuL0rh0ZPN0Rb8"],"Subsection:Number":["1.1"],"Entry Text":"Phone number","Assessment Section":["recW5wjaveWt8ej9X"],"Question:Label":["Mobile phone number"],"Name":"Mobile phone number","Question Count":1,"Number":"1.1.3"},"createdTime":"2019-06-13T05:03:45.000Z"},{"id":"recY9KcvuJVhYssM3","fields":{"Question":["recFTaRmDnG7LdqjF"],"Order":4,"Optional":true,"Assessment Subsection":["recLuL0rh0ZPN0Rb8"],"Subsection:Number":["1.1"],"Entry Text":"Birthday","Assessment Section":["recW5wjaveWt8ej9X"],"Question:Label":["Birthday"],"Name":"Birthday","Question Count":1,"Number":"1.1.4"},"createdTime":"2020-03-06T06:52:10.000Z"},{"id":"receHLCCM7zqy2vRB","fields":{"Question":["recgN59EzBMB8o7bp"],"Order":5,"Optional":true,"Assessment Subsection":["recLuL0rh0ZPN0Rb8"],"Subsection:Number":["1.1"],"Entry Text":"Zip code","Assessment Section":["recW5wjaveWt8ej9X"],"Question:Label":["Zip code"],"Name":"Zip code","Question Count":1,"Number":"1.1.5"},"createdTime":"2020-03-06T06:55:26.000Z"},{"id":"recROMlzUafxQVgAE","fields":{"Question":["recohos5WtihIqlhl"],"Order":1,"Optional":true,"Assessment Subsection":["recL2xIWiJlYtjp0q"],"Subsection:Number":["2.2"],"Entry Text":"My Goal","Assessment Section":["recrAqdmqSolEdJ5y"],"Question:Label":["What is your career goal?"],"Name":"What is your career goal?","Question Count":1,"Number":"2.2.1"},"createdTime":"2020-05-08T17:52:59.000Z"},{"id":"recTQZjBcKuuuQidH","fields":{"Question":["reciquqWJom8D43QI"],"Order":1,"Assessment Subsection":["reciuMFImzTFxi6nI"],"Subsection:Number":["3.3"],"Entry Text":"Highest level of education","Assessment Section":["rec0QvDOSx1CCUcFV"],"Question:Label":["What is your highest level of education?"],"Name":"What is your highest level of education?","Question Count":1,"Number":"3.3.1"},"createdTime":"2019-06-13T04:58:28.000Z"},{"id":"recwfZKBTPuceSbqS","fields":{"Question":["recTCMwWbEpVUlv1l"],"Order":2,"Optional":true,"Assessment Subsection":["reciuMFImzTFxi6nI"],"Subsection:Number":["3.3"],"Entry Text":"School","Assessment Section":["rec0QvDOSx1CCUcFV"],"Question:Label":["What school did you attend for your highest level of education?"],"Name":"What school did you attend for your highest level of education?","Question Count":1,"Number":"3.3.2"},"createdTime":"2020-05-08T19:06:58.000Z"},{"id":"recuGIotJZuga1nE6","fields":{"Question":["recjxmI0H7hHEUXRZ"],"Order":3,"Optional":true,"Assessment Subsection":["reciuMFImzTFxi6nI"],"Subsection:Number":["3.3"],"Entry Text":"Major / Field of Study","Assessment Section":["rec0QvDOSx1CCUcFV"],"Question:Label":["What was your major / field of study?"],"Name":"What was your major / field of study?","Question Count":1,"Number":"3.3.3"},"createdTime":"2020-05-08T19:07:36.000Z"},{"id":"recalkzEreiRTMwXC","fields":{"Question":["recC9E9rYIybBwwV7"],"Order":4,"Optional":true,"Assessment Subsection":["reciuMFImzTFxi6nI"],"Subsection:Number":["3.3"],"Entry Text":"Years Attended (Start)","Assessment Section":["rec0QvDOSx1CCUcFV"],"Question:Label":["What year did you start attending this school?"],"Name":"What year did you start attending this school?","Question Count":1,"Number":"3.3.4"},"createdTime":"2020-05-08T20:23:56.000Z"},{"id":"reckPymsCcTaqndZn","fields":{"Question":["recGDJ7KJwJvsqxiO"],"Order":5,"Optional":true,"Assessment Subsection":["reciuMFImzTFxi6nI"],"Subsection:Number":["3.3"],"Entry Text":"Years Attended (End)","Assessment Section":["rec0QvDOSx1CCUcFV"],"Question:Label":["What year did you complete attending this school?"],"Name":"What year did you complete attending this school?","Question Count":1,"Number":"3.3.5"},"createdTime":"2020-05-08T21:15:30.000Z"},{"id":"rec5fgIkF4nvFRNJV","fields":{"Question":["recyOfqkNspqhLYEc"],"Order":1,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"Current employment status","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["What's your current employment status?"],"Name":"What's your current employment status?","Question Count":1,"Number":"4.4.1"},"createdTime":"2019-06-13T05:03:45.000Z"},{"id":"recGNsmHZ61dMS9sZ","fields":{"Question":["rec89z2RcqJvMXEV4"],"Order":2,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"Length of employment status","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["How long has this been your employment status?"],"Name":"How long has this been your employment status?","Question Count":1,"Number":"4.4.2"},"createdTime":"2019-10-31T14:45:47.000Z"},{"id":"recxUPx4oAz0WaEdG","fields":{"Question":["recNNm1JNICZ2mhje"],"Order":3,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"COVID","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["Has the COVID-19 pandemic affected your current employment status?"],"Name":"Has the COVID-19 pandemic affected your current employment status?","Question Count":1,"Number":"4.4.3"},"createdTime":"2020-05-08T19:08:55.000Z"},{"id":"recrd06FvSmS8hwGN","fields":{"Question":["recqI5PFYk7n8XrVV"],"Order":4,"Optional":true,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"Most recent job title","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["What is the most recent job title you have held?"],"Name":"What is the most recent job title you have held?","Question Count":1,"Number":"4.4.4"},"createdTime":"2020-01-30T15:49:27.000Z"},{"id":"rectnKs1X9Bn3WN3g","fields":{"Question":["recQI6aczgHAPxbe4"],"Order":5,"Optional":true,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"Most recent organization","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["What is the most recent organization you worked for?"],"Name":"What is the most recent organization you worked for?","Question Count":1,"Number":"4.4.5"},"createdTime":"2020-03-06T07:02:35.000Z"},{"id":"recMFtzCapQpRvOAj","fields":{"Question Group":["reciqSMaM5HThVRdc"],"Order":6,"Optional":true,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Question Group:Questions":["recZqohjeA6yCY54K","recDaRtvJEh0fx0rH"],"Subsection:Number":["4.4"],"Entry Text":"Job Date Range","Assessment Section":["recIMec75GXw18FhH"],"Question Group:Label":["When did you start and end your most recent job?"],"Name":"When did you start and end your most recent job?","Question Group:Question Count":[2],"Question Count":[2],"Number":"4.4.6"},"createdTime":"2020-06-11T14:58:32.000Z"},{"id":"recDgN33nOpQoyJZ0","fields":{"Question":["recbhCJUmJMNkgvyY"],"Order":8,"Optional":true,"Assessment Subsection":["recWJEzKO3jeZhGdJ"],"Subsection:Number":["4.4"],"Entry Text":"This is my current job","Assessment Section":["recIMec75GXw18FhH"],"Question:Label":["This is my current job"],"Name":"This is my current job","Question Count":1,"Number":"4.4.8"},"createdTime":"2020-05-11T12:51:39.000Z"},{"id":"recKMijt0URJShXhg","fields":{"Question Group":["recu6EtEOAeRx4gfI"],"Order":1,"Assessment Subsection":["rec3Yc7EWft3kwWcx"],"Question Group:Questions":["recm4nmSaaNb8NUUv","recZzSrIZMH47MW78","recWiiQsOCP4eJdtf","rec8IAX4tryrYmcmV","rec6CVqX5BKJwM8Nl","recC4GI8RxJcHZ0oT"],"Subsection:Number":["5.5"],"Entry Text":"Essential Items","Assessment Section":["recCDYsaholcx6cfv"],"Question Group:Label":["Do you have these essential items for your search? Don't worry if you don't. Our platform can help you create or refine them."],"Name":"Do you have these essential items for your search? Don't worry if you don't. Our platform can help you create or refine them.","Question Group:Question Count":[6],"Question Count":[6],"Number":"5.5.1"},"createdTime":"2019-06-13T05:03:45.000Z"},{"id":"rec8QGwEsjFdDXMAg","fields":{"Question Group":["rec3Nz5r3aprcBP3e"],"Order":1,"Optional":true,"Assessment Subsection":["recJ4vudqm3BnU3zK"],"Question Group:Questions":["recUZFPSP67PxoJlb","recoorr1Yx9HKZvn6","recmsn7rOpOEwon7k","recq89GpiEzBPW0Bj","recy9xiN1b8ZkrnPB","recgB92pWSBEVh4h6","recvPRnBdSndwqWWm","recKBN8zsHZreV8PS"],"Subsection:Number":["6.6"],"Entry Text":"Basic Needs","Assessment Section":["rec5rl5S4dlNq0y99"],"Question Group:Label":["What you like more information about any of these services?"],"Name":"What you like more information about any of these services?","Question Group:Question Count":[8],"Question Count":[8],"Number":"6.6.1"},"createdTime":"2019-06-13T05:03:45.000Z"}]}
+{
+  "records": [
+    {
+      "id": "recYONnfuLAEV6ONS",
+      "fields": {
+        "Internal Notes": "Currently auto-populated",
+        "Question": [
+          "recwKxBPzV84ZWIJ5"
+        ],
+        "Order": 1,
+        "Assessment Subsection": [
+          "recLuL0rh0ZPN0Rb8"
+        ],
+        "Subsection:Number": [
+          "1.1"
+        ],
+        "Entry Text": "Full name",
+        "Assessment Section": [
+          "recW5wjaveWt8ej9X"
+        ],
+        "Question:Label": [
+          "Full name"
+        ],
+        "Name": "Full name",
+        "Question Count": 1,
+        "Number": "1.1.1"
+      },
+      "createdTime": "2020-03-06T06:52:12.000Z"
+    },
+    {
+      "id": "recEcw1JVST0tzU7J",
+      "fields": {
+        "Internal Notes": "Auto-populated and used so that we can key predicates off the user's email address.\n\nIn the future, maybe make this disabled if using SSO but enabled if using text auth?",
+        "Question": [
+          "recbIKyicFBLz3mbI"
+        ],
+        "Order": 2,
+        "Assessment Subsection": [
+          "recLuL0rh0ZPN0Rb8"
+        ],
+        "Subsection:Number": [
+          "1.1"
+        ],
+        "Entry Text": "Email",
+        "Assessment Section": [
+          "recW5wjaveWt8ej9X"
+        ],
+        "Question:Label": [
+          "Email address"
+        ],
+        "Name": "Email address",
+        "Question Count": 1,
+        "Number": "1.1.2"
+      },
+      "createdTime": "2019-06-28T04:08:04.000Z"
+    },
+    {
+      "id": "recnByH6HIktAHCtR",
+      "fields": {
+        "Question": [
+          "recDkvWeqvMxahFT2"
+        ],
+        "Order": 3,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recLuL0rh0ZPN0Rb8"
+        ],
+        "Subsection:Number": [
+          "1.1"
+        ],
+        "Entry Text": "Phone number",
+        "Assessment Section": [
+          "recW5wjaveWt8ej9X"
+        ],
+        "Question:Label": [
+          "Mobile phone number"
+        ],
+        "Name": "Mobile phone number",
+        "Question Count": 1,
+        "Number": "1.1.3"
+      },
+      "createdTime": "2019-06-13T05:03:45.000Z"
+    },
+    {
+      "id": "recY9KcvuJVhYssM3",
+      "fields": {
+        "Question": [
+          "recFTaRmDnG7LdqjF"
+        ],
+        "Order": 4,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recLuL0rh0ZPN0Rb8"
+        ],
+        "Subsection:Number": [
+          "1.1"
+        ],
+        "Entry Text": "Birthday",
+        "Assessment Section": [
+          "recW5wjaveWt8ej9X"
+        ],
+        "Question:Label": [
+          "Birthday"
+        ],
+        "Name": "Birthday",
+        "Question Count": 1,
+        "Number": "1.1.4"
+      },
+      "createdTime": "2020-03-06T06:52:10.000Z"
+    },
+    {
+      "id": "receHLCCM7zqy2vRB",
+      "fields": {
+        "Question": [
+          "recgN59EzBMB8o7bp"
+        ],
+        "Order": 5,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recLuL0rh0ZPN0Rb8"
+        ],
+        "Subsection:Number": [
+          "1.1"
+        ],
+        "Entry Text": "Zip code",
+        "Assessment Section": [
+          "recW5wjaveWt8ej9X"
+        ],
+        "Question:Label": [
+          "Zip code"
+        ],
+        "Name": "Zip code",
+        "Question Count": 1,
+        "Number": "1.1.5"
+      },
+      "createdTime": "2020-03-06T06:55:26.000Z"
+    },
+    {
+      "id": "recROMlzUafxQVgAE",
+      "fields": {
+        "Question": [
+          "recohos5WtihIqlhl"
+        ],
+        "Order": 1,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recL2xIWiJlYtjp0q"
+        ],
+        "Subsection:Number": [
+          "2.2"
+        ],
+        "Entry Text": "My Goal",
+        "Assessment Section": [
+          "recrAqdmqSolEdJ5y"
+        ],
+        "Question:Label": [
+          "What is your career goal?"
+        ],
+        "Name": "What is your career goal?",
+        "Question Count": 1,
+        "Number": "2.2.1"
+      },
+      "createdTime": "2020-05-08T17:52:59.000Z"
+    },
+    {
+      "id": "recTQZjBcKuuuQidH",
+      "fields": {
+        "Question": [
+          "reciquqWJom8D43QI"
+        ],
+        "Order": 1,
+        "Assessment Subsection": [
+          "reciuMFImzTFxi6nI"
+        ],
+        "Subsection:Number": [
+          "3.3"
+        ],
+        "Entry Text": "Highest level of education",
+        "Assessment Section": [
+          "rec0QvDOSx1CCUcFV"
+        ],
+        "Question:Label": [
+          "What is your highest level of education?"
+        ],
+        "Name": "What is your highest level of education?",
+        "Question Count": 1,
+        "Number": "3.3.1"
+      },
+      "createdTime": "2019-06-13T04:58:28.000Z"
+    },
+    {
+      "id": "recwfZKBTPuceSbqS",
+      "fields": {
+        "Question": [
+          "recTCMwWbEpVUlv1l"
+        ],
+        "Order": 2,
+        "Optional": true,
+        "Assessment Subsection": [
+          "reciuMFImzTFxi6nI"
+        ],
+        "Subsection:Number": [
+          "3.3"
+        ],
+        "Entry Text": "School",
+        "Assessment Section": [
+          "rec0QvDOSx1CCUcFV"
+        ],
+        "Question:Label": [
+          "What school did you attend for your highest level of education?"
+        ],
+        "Name": "What school did you attend for your highest level of education?",
+        "Question Count": 1,
+        "Number": "3.3.2"
+      },
+      "createdTime": "2020-05-08T19:06:58.000Z"
+    },
+    {
+      "id": "recuGIotJZuga1nE6",
+      "fields": {
+        "Question": [
+          "recjxmI0H7hHEUXRZ"
+        ],
+        "Order": 3,
+        "Optional": true,
+        "Assessment Subsection": [
+          "reciuMFImzTFxi6nI"
+        ],
+        "Subsection:Number": [
+          "3.3"
+        ],
+        "Entry Text": "Major / Field of Study",
+        "Assessment Section": [
+          "rec0QvDOSx1CCUcFV"
+        ],
+        "Question:Label": [
+          "What was your major / field of study?"
+        ],
+        "Name": "What was your major / field of study?",
+        "Question Count": 1,
+        "Number": "3.3.3"
+      },
+      "createdTime": "2020-05-08T19:07:36.000Z"
+    },
+    {
+      "id": "recalkzEreiRTMwXC",
+      "fields": {
+        "Question": [
+          "recC9E9rYIybBwwV7"
+        ],
+        "Order": 4,
+        "Optional": true,
+        "Assessment Subsection": [
+          "reciuMFImzTFxi6nI"
+        ],
+        "Subsection:Number": [
+          "3.3"
+        ],
+        "Entry Text": "Years Attended (Start)",
+        "Assessment Section": [
+          "rec0QvDOSx1CCUcFV"
+        ],
+        "Question:Label": [
+          "What year did you start attending this school?"
+        ],
+        "Name": "What year did you start attending this school?",
+        "Question Count": 1,
+        "Number": "3.3.4"
+      },
+      "createdTime": "2020-05-08T20:23:56.000Z"
+    },
+    {
+      "id": "reckPymsCcTaqndZn",
+      "fields": {
+        "Question": [
+          "recGDJ7KJwJvsqxiO"
+        ],
+        "Order": 5,
+        "Optional": true,
+        "Assessment Subsection": [
+          "reciuMFImzTFxi6nI"
+        ],
+        "Subsection:Number": [
+          "3.3"
+        ],
+        "Entry Text": "Years Attended (End)",
+        "Assessment Section": [
+          "rec0QvDOSx1CCUcFV"
+        ],
+        "Question:Label": [
+          "What year did you complete attending this school?"
+        ],
+        "Name": "What year did you complete attending this school?",
+        "Question Count": 1,
+        "Number": "3.3.5"
+      },
+      "createdTime": "2020-05-08T21:15:30.000Z"
+    },
+    {
+      "id": "rec5fgIkF4nvFRNJV",
+      "fields": {
+        "Question": [
+          "recyOfqkNspqhLYEc"
+        ],
+        "Order": 1,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "Current employment status",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "What's your current employment status?"
+        ],
+        "Name": "What's your current employment status?",
+        "Question Count": 1,
+        "Number": "4.4.1"
+      },
+      "createdTime": "2019-06-13T05:03:45.000Z"
+    },
+    {
+      "id": "recGNsmHZ61dMS9sZ",
+      "fields": {
+        "Question": [
+          "rec89z2RcqJvMXEV4"
+        ],
+        "Order": 2,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "Length of employment status",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "How long has this been your employment status?"
+        ],
+        "Name": "How long has this been your employment status?",
+        "Question Count": 1,
+        "Number": "4.4.2"
+      },
+      "createdTime": "2019-10-31T14:45:47.000Z"
+    },
+    {
+      "id": "recxUPx4oAz0WaEdG",
+      "fields": {
+        "Question": [
+          "recNNm1JNICZ2mhje"
+        ],
+        "Order": 3,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "COVID",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "Has the COVID-19 pandemic affected your current employment status?"
+        ],
+        "Name": "Has the COVID-19 pandemic affected your current employment status?",
+        "Question Count": 1,
+        "Number": "4.4.3"
+      },
+      "createdTime": "2020-05-08T19:08:55.000Z"
+    },
+    {
+      "id": "recrd06FvSmS8hwGN",
+      "fields": {
+        "Question": [
+          "recqI5PFYk7n8XrVV"
+        ],
+        "Order": 4,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "Most recent job title",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "What is the most recent job title you have held?"
+        ],
+        "Name": "What is the most recent job title you have held?",
+        "Question Count": 1,
+        "Number": "4.4.4"
+      },
+      "createdTime": "2020-01-30T15:49:27.000Z"
+    },
+    {
+      "id": "rectnKs1X9Bn3WN3g",
+      "fields": {
+        "Question": [
+          "recQI6aczgHAPxbe4"
+        ],
+        "Order": 5,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "Most recent organization",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "What is the most recent organization you worked for?"
+        ],
+        "Name": "What is the most recent organization you worked for?",
+        "Question Count": 1,
+        "Number": "4.4.5"
+      },
+      "createdTime": "2020-03-06T07:02:35.000Z"
+    },
+    {
+      "id": "recMFtzCapQpRvOAj",
+      "fields": {
+        "Question Group": [
+          "reciqSMaM5HThVRdc"
+        ],
+        "Order": 6,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Question Group:Questions": [
+          "recZqohjeA6yCY54K",
+          "recDaRtvJEh0fx0rH"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "Job Date Range",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question Group:Label": [
+          "When did you start and end your most recent job?"
+        ],
+        "Name": "When did you start and end your most recent job?",
+        "Question Group:Question Count": [
+          2
+        ],
+        "Question Count": [
+          2
+        ],
+        "Number": "4.4.6"
+      },
+      "createdTime": "2020-06-11T14:58:32.000Z"
+    },
+    {
+      "id": "recDgN33nOpQoyJZ0",
+      "fields": {
+        "Question": [
+          "recbhCJUmJMNkgvyY"
+        ],
+        "Order": 8,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recWJEzKO3jeZhGdJ"
+        ],
+        "Subsection:Number": [
+          "4.4"
+        ],
+        "Entry Text": "This is my current job",
+        "Assessment Section": [
+          "recIMec75GXw18FhH"
+        ],
+        "Question:Label": [
+          "This is my current job"
+        ],
+        "Name": "This is my current job",
+        "Question Count": 1,
+        "Number": "4.4.8"
+      },
+      "createdTime": "2020-05-11T12:51:39.000Z"
+    },
+    {
+      "id": "recKMijt0URJShXhg",
+      "fields": {
+        "Question Group": [
+          "recu6EtEOAeRx4gfI"
+        ],
+        "Order": 1,
+        "Assessment Subsection": [
+          "rec3Yc7EWft3kwWcx"
+        ],
+        "Question Group:Questions": [
+          "recm4nmSaaNb8NUUv",
+          "recZzSrIZMH47MW78",
+          "recWiiQsOCP4eJdtf",
+          "rec8IAX4tryrYmcmV",
+          "rec6CVqX5BKJwM8Nl",
+          "recC4GI8RxJcHZ0oT"
+        ],
+        "Subsection:Number": [
+          "5.5"
+        ],
+        "Entry Text": "Essential Items",
+        "Assessment Section": [
+          "recCDYsaholcx6cfv"
+        ],
+        "Question Group:Label": [
+          "Do you have these essential items for your search? Don't worry if you don't. Our platform can help you create or refine them."
+        ],
+        "Name": "Do you have these essential items for your search? Don't worry if you don't. Our platform can help you create or refine them.",
+        "Question Group:Question Count": [
+          6
+        ],
+        "Question Count": [
+          6
+        ],
+        "Number": "5.5.1"
+      },
+      "createdTime": "2019-06-13T05:03:45.000Z"
+    },
+    {
+      "id": "rec8QGwEsjFdDXMAg",
+      "fields": {
+        "Question Group": [
+          "rec3Nz5r3aprcBP3e"
+        ],
+        "Order": 1,
+        "Optional": true,
+        "Assessment Subsection": [
+          "recJ4vudqm3BnU3zK"
+        ],
+        "Question Group:Questions": [
+          "recUZFPSP67PxoJlb",
+          "recoorr1Yx9HKZvn6",
+          "recmsn7rOpOEwon7k",
+          "recq89GpiEzBPW0Bj",
+          "recy9xiN1b8ZkrnPB",
+          "recgB92pWSBEVh4h6",
+          "recvPRnBdSndwqWWm",
+          "recKBN8zsHZreV8PS"
+        ],
+        "Subsection:Number": [
+          "6.6"
+        ],
+        "Entry Text": "Basic Needs",
+        "Assessment Section": [
+          "rec5rl5S4dlNq0y99"
+        ],
+        "Question Group:Label": [
+          "What you like more information about any of these services?"
+        ],
+        "Name": "What you like more information about any of these services?",
+        "Question Group:Question Count": [
+          8
+        ],
+        "Question Count": [
+          8
+        ],
+        "Number": "6.6.1"
+      },
+      "createdTime": "2019-06-13T05:03:45.000Z"
+    }
+  ]
+}


### PR DESCRIPTION
This disables the required status on fields on the education and employment sections of the assessment flow. This is done by 1) setting the `optional` property in the static API for `Assessment Entities`, and 2) adjusting the validation functions to respect the `optional` property.